### PR TITLE
Make data sources configurable, validate app name

### DIFF
--- a/lib/deploy/data.ts
+++ b/lib/deploy/data.ts
@@ -15,7 +15,6 @@
  */
 
 import {
-    GitProject,
     HandlerContext,
     logger,
     Project,
@@ -30,11 +29,13 @@ import * as dockerfileParser from "docker-file-parser";
 import * as stringify from "json-stringify-safe";
 import * as _ from "lodash";
 import { DeepPartial } from "ts-essentials";
+import { validName } from "../kubernetes/name";
 import { defaultNamespace } from "../kubernetes/namespace";
 import { KubernetesApplication } from "../kubernetes/request";
 import {
     goalEventSlug,
     KubernetesDeploy,
+    KubernetesDeployDataSources,
     KubernetesDeployRegistration,
 } from "./goal";
 import { loadKubernetesSpec } from "./spec";
@@ -47,14 +48,20 @@ import { loadKubernetesSpec } from "./spec";
 export const sdmPackK8s = "@atomist/sdm-pack-k8s";
 
 /**
- * Generate KubernetesApplication from project and goal invocation.
- * This function used [[defaultDeploymentData]] to produce initial
- * [[KubernetesApplication]] data.  It then merges in any object
- * provided by `goalEvent.data[[[sdmPackk8]]]`, with the latter taking
- * precedence.  Then, if `registration.applicationData` is truthy, it
- * calls that function, passing the merged value of the Kubernetes
- * application, and uses its return value as
- * `goalEvent.data[[[sdmPackk8]]]`.
+ * Generate KubernetesApplication from goal, goal registration,
+ * project, and goal invocation.  The priority of the various sources
+ * of KubernetesApplication data are, from lowest to highest:
+ *
+ * 1.  Starting point is `{ ns: defaultNamespace }`
+ * 2.  [[KubernetesDeployDataSources.SdmConfiguration]]
+ * 3.  [[defaultKubernetesApplication]]
+ * 4.  [[KubernetesDeployDataSources.Dockerfile]]
+ * 5.  The various partial Kubernetes specs under `.atomist/kubernetes`
+ * 6.  [[KubernetesDeployDataSources.GoalEvent]]
+ * 7.  [[KubernetesDeployRegistration.applicationData]]
+ *
+ * Specific sources can be enabled/disabled via the
+ * [[KubernetesDeployRegistration.dataSources]].
  *
  * @param k8Deploy Kubernetes deployment goal
  * @param registration Goal registration/configuration for `k8Deploy`
@@ -69,26 +76,41 @@ export function generateKubernetesGoalEventData(
     return k8Deploy.sdm.configuration.sdm.projectLoader.doWithProject({ ...goalInvocation, readOnly: true }, async p => {
 
         const { context, goalEvent } = goalInvocation;
-        const defaultData: any = {};
-        defaultData[sdmPackK8s] = await defaultKubernetesApplication(p, goalEvent, k8Deploy, context);
 
-        const slug = goalEventSlug(goalEvent);
-        let eventData: any;
-        try {
-            eventData = JSON.parse(goalEvent.data || "{}");
-        } catch (e) {
-            logger.warn(`Failed to parse goal event data for ${slug} as JSON: ${e.message}`);
-            logger.warn(`Ignoring current value of goal event data: ${goalEvent.data}`);
-            eventData = {};
+        const sdmConfigAppData: Partial<KubernetesApplication> = (registration.dataSources.includes(KubernetesDeployDataSources.SdmConfiguration)) ?
+            _.get(k8Deploy, "sdm.configuration.sdm.k8s.app", {}) : {};
+
+        const defaultAppData: Partial<KubernetesApplication> = await defaultKubernetesApplication(goalEvent, k8Deploy, context);
+
+        const dockerfileAppData: Partial<KubernetesApplication> = (registration.dataSources.includes(KubernetesDeployDataSources.Dockerfile)) ?
+            await dockerfileKubernetesApplication(p) : {};
+
+        const specAppData: Partial<KubernetesApplication> = await repoSpecsKubernetsApplication(p, registration);
+
+        const mergedAppData = _.merge({ ns: defaultNamespace }, sdmConfigAppData, defaultAppData, dockerfileAppData, specAppData);
+
+        const eventAppData: any = {};
+        eventAppData[sdmPackK8s] = mergedAppData;
+
+        if (registration.dataSources.includes(KubernetesDeployDataSources.GoalEvent)) {
+            const slug = goalEventSlug(goalEvent);
+            let eventData: any;
+            try {
+                eventData = JSON.parse(goalEvent.data || "{}");
+            } catch (e) {
+                logger.warn(`Failed to parse goal event data for ${slug} as JSON: ${e.message}`);
+                logger.warn(`Ignoring current value of goal event data: ${goalEvent.data}`);
+                eventData = {};
+            }
+            _.merge(eventAppData, eventData);
         }
-        const mergedData = _.merge(defaultData, eventData);
 
         if (registration.applicationData) {
-            const callbackData = await registration.applicationData(mergedData[sdmPackK8s], p, k8Deploy, goalEvent, context);
-            mergedData[sdmPackK8s] = callbackData;
+            const callbackAppData = await registration.applicationData(eventAppData[sdmPackK8s], p, k8Deploy, goalEvent, context);
+            eventAppData[sdmPackK8s] = callbackAppData;
         }
 
-        goalEvent.data = JSON.stringify(mergedData);
+        goalEvent.data = JSON.stringify(eventAppData);
         return goalEvent;
     });
 }
@@ -118,70 +140,30 @@ export function getKubernetesGoalEventData(goalEvent: SdmGoalEvent): KubernetesA
 }
 
 /**
- * Given the project, event, [[KubernetesDeployment]] goal, and
- * handler context generate a default [[KubernetesApplication]] object
- * that should be suitable for deploying simple, microservices.
+ * Given the goal event, [[KubernetesDeploy]] goal, and
+ * handler context generate a default [[KubernetesApplication]] object.
  *
- * If the SDM configuration contains a `k8s.app` property, i.e.,
- * `k8Deploy.sdm.configuration.sdm.k8s.app`, it is used as the basis
- * for the default [[KubernetesApplication]] object.
+ * This function uses [[defaultImage]] to determine the image.
  *
- * This function reads partial Kubernetes specs from the
- * `.atomist/kubernetes` directory of the project, if any exist.
- * Specifically it looks for JSON and YAML files with the base names
- * "deployment", "service", "ingress", "role", "service-account", and
- * "role-binding".
- *
- * It also uses [[defaultImage]] and [[dockerPort]] to further
- * populated default property values from information in the
- * repository and event.
- *
- * Any values obtained from the repository/project/event/goal override
- * those in the SDM configuration `k8s` property.
- *
- * @param p Project being deployed
  * @param goalEvent SDM Kubernetes deployment goal event
  * @param k8Deploy Kubernetes deployment goal configuration
  * @param context Handler context
  * @return a valid default KubernetesApplication for this SDM goal deployment event
  */
 export async function defaultKubernetesApplication(
-    p: GitProject,
     goalEvent: SdmGoalEvent,
     k8Deploy: KubernetesDeploy,
     context: HandlerContext,
-): Promise<KubernetesApplication> {
-
-    const configAppData: Partial<KubernetesApplication> = _.get(k8Deploy, "sdm.configuration.sdm.k8s.app", {});
+): Promise<Partial<KubernetesApplication>> {
 
     const workspaceId = context.workspaceId;
-    const name = goalEvent.repo.name;
-    const ns = configAppData.ns || defaultNamespace;
+    const name = validName(goalEvent.repo.name);
     const image = await defaultImage(goalEvent, k8Deploy, context);
-    const port = await dockerPort(p);
-
-    const deploymentSpec: DeepPartial<k8s.V1Deployment> = await loadKubernetesSpec(p, "deployment");
-    const serviceSpec: DeepPartial<k8s.V1Service> = await loadKubernetesSpec(p, "service");
-    const ingressSpec: DeepPartial<k8s.V1beta1Ingress> = await loadKubernetesSpec(p, "ingress");
-    const roleSpec: DeepPartial<k8s.V1Role> = await loadKubernetesSpec(p, "role");
-    const serviceAccountSpec: DeepPartial<k8s.V1ServiceAccount> = await loadKubernetesSpec(p, "service-account");
-    const roleBindingSpec: DeepPartial<k8s.V1RoleBinding> = await loadKubernetesSpec(p, "role-binding");
-
-    const repoAppData: KubernetesApplication = {
+    return {
         workspaceId,
         name,
-        ns,
         image,
-        port,
-        deploymentSpec,
-        serviceSpec,
-        ingressSpec,
-        roleSpec,
-        serviceAccountSpec,
-        roleBindingSpec,
     };
-
-    return _.merge({}, configAppData, repoAppData);
 }
 
 /**
@@ -220,6 +202,43 @@ export async function dockerPort(p: Project): Promise<number | undefined> {
     return undefined;
 }
 
+/** Package return of [[dockerPort]] in [[KubernetesApplication]]. */
+async function dockerfileKubernetesApplication(p: Project): Promise<Partial<KubernetesApplication>> {
+    const port = await dockerPort(p);
+    return (port) ? { port } : {};
+}
+
+/**
+ * Read configured Kubernetes partial specs from repository.
+ *
+ * @param p Project to look for specs
+ * @param registration Configuration of KubernetesDeploy goal
+ * @return KubernetesApplication object with requested specs populated
+ */
+export async function repoSpecsKubernetsApplication(p: Project, r: KubernetesDeployRegistration): Promise<Partial<KubernetesApplication>> {
+    const deploymentSpec: DeepPartial<k8s.V1Deployment> = (r.dataSources.includes(KubernetesDeployDataSources.DeploymentSpec)) ?
+        await loadKubernetesSpec(p, "deployment") : undefined;
+    const serviceSpec: DeepPartial<k8s.V1Service> = (r.dataSources.includes(KubernetesDeployDataSources.ServiceSpec)) ?
+        await loadKubernetesSpec(p, "service") : undefined;
+    const ingressSpec: DeepPartial<k8s.V1beta1Ingress> = (r.dataSources.includes(KubernetesDeployDataSources.IngressSpec)) ?
+        await loadKubernetesSpec(p, "ingress") : undefined;
+    const roleSpec: DeepPartial<k8s.V1Role> = (r.dataSources.includes(KubernetesDeployDataSources.RoleSpec)) ?
+        await loadKubernetesSpec(p, "role") : undefined;
+    const serviceAccountSpec: DeepPartial<k8s.V1ServiceAccount> = (r.dataSources.includes(KubernetesDeployDataSources.ServiceAccountSpec)) ?
+        await loadKubernetesSpec(p, "service-account") : undefined;
+    const roleBindingSpec: DeepPartial<k8s.V1RoleBinding> = (r.dataSources.includes(KubernetesDeployDataSources.RoleBindingSpec)) ?
+        await loadKubernetesSpec(p, "role-binding") : undefined;
+
+    return {
+        deploymentSpec,
+        serviceSpec,
+        ingressSpec,
+        roleSpec,
+        serviceAccountSpec,
+        roleBindingSpec,
+    };
+}
+
 /**
  * Remove any invalid characters from Docker image name component
  * `name` to make it a valid Docker image name component.  If
@@ -249,7 +268,10 @@ export async function dockerPort(p: Project): Promise<number | undefined> {
  * @return Valid Docker image name component.
  */
 function dockerImageNameComponent(name: string, hubOwner: boolean = false): string {
-    const cleanName = name.toLocaleLowerCase().replace(/^[^a-z0-9]+/, "").replace(/[^a-z0-9]+$/, "").replace(/[^-_/.a-z0-9]+/g, "");
+    const cleanName = name.toLocaleLowerCase()
+        .replace(/^[^a-z0-9]+/, "")
+        .replace(/[^a-z0-9]+$/, "")
+        .replace(/[^-_/.a-z0-9]+/g, "");
     if (hubOwner) {
         return cleanName.replace(/[^a-z0-9]+/g, "");
     } else {

--- a/lib/deploy/goal.ts
+++ b/lib/deploy/goal.ts
@@ -54,6 +54,30 @@ export type ApplicationDataCallback =
     (a: KubernetesApplication, p: GitProject, g: KubernetesDeploy, e: SdmGoalEvent, ctx: HandlerContext) => Promise<KubernetesApplication>;
 
 /**
+ * Sources of information for Kubernetes goal application data.
+ */
+export enum KubernetesDeployDataSources {
+    /** Read deployment spec from `.atomist/kubernetes`. */
+    DeploymentSpec = "DeploymentSpec",
+    /** Read EXPOSE from Dockerfile to get service port. */
+    Dockerfile = "Dockerfile",
+    /** Parse `goalEvent.` as JSON. */
+    GoalEvent = "GoalEvent",
+    /** Read ingress spec from `.atomist/kubernetes`. */
+    IngressSpec = "IngressSpec",
+    /** Read role-binding spec from `.atomist/kubernetes`. */
+    RoleBindingSpec = "RoleBindingSpec",
+    /** Read role spec from `.atomist/kubernetes`. */
+    RoleSpec = "RoleSpec",
+    /** Load `sdm.configuration.sdm.k8s.app`. */
+    SdmConfiguration = "SdmConfiguration",
+    /** Read service-account spec from `.atomist/kubernetes`. */
+    ServiceAccountSpec = "ServiceAccountSpec",
+    /** Read service spec from `.atomist/kubernetes`. */
+    ServiceSpec = "ServiceSpec",
+}
+
+/**
  * Registration object to pass to KubernetesDeployment goal to
  * configure how deployment works.
  */
@@ -64,17 +88,23 @@ export interface KubernetesDeployRegistration {
      */
     applicationData?: ApplicationDataCallback;
     /**
-     * It not set (falsey), this SDM will fulfill its own Kubernetes
-     * deployment goals.  If set, its value defines the name of the
-     * SDM that will fulfill the goal.  In this case, there should be
-     * another SDM running whose name, i.e., its name as defined in
-     * its registration/package.json, is the same as this name.
+     * If falsey, this SDM will fulfill its own Kubernetes deployment
+     * goals.  If set, its value defines the name of the SDM that will
+     * fulfill the goal.  In this case, there should be another SDM
+     * running whose name, i.e., its name as defined in its
+     * registration/package.json, is the same as this name.
      */
     name?: string;
     /**
      * Optional push test for this goal implementation.
      */
     pushTest?: PushTest;
+    /**
+     * Determine what parts of the repository to use to generate the
+     * initial Kubernetes goal application data.  It no value is
+     * provided, all sources are used.
+     */
+    dataSources?: KubernetesDeployDataSources[];
 }
 
 /**
@@ -166,6 +196,22 @@ export class KubernetesDeploy extends FulfillableGoalWithRegistrations<Kubernete
 }
 
 /**
+ * Populate data sources properrty of registration with all possible
+ * KubernetesGoalDataSources if it is not defined.  Otherwise, leave
+ * it as is.  The registration object is modified directly and
+ * returned.
+ *
+ * @param registration Kubernetes deploy object registration
+ * @return registration with data sources
+ */
+export function defaultDataSources(registration: KubernetesDeployRegistration): KubernetesDeployRegistration {
+    if (!registration.dataSources) {
+        registration.dataSources = Object.values(KubernetesDeployDataSources);
+    }
+    return registration;
+}
+
+/**
  * If in SDM team mode, this goal executor generates and stores the
  * Kubernetes application data for deploying an application to
  * Kubernetes.  It returns the augmented SdmGoalEvent with the
@@ -173,6 +219,9 @@ export class KubernetesDeploy extends FulfillableGoalWithRegistrations<Kubernete
  * state of the SdmGoalEvent set to "in_process".  The actual
  * deployment is done by the [[kubernetesDeployHandler]] event
  * handler.
+ *
+ * It will call [[defaultDataSources]] to populate the default
+ * repository data sources if none are provided in the registration.
  *
  * If in SDM local mode, generate the Kubernetes application data and
  * deploy the application.
@@ -183,6 +232,7 @@ export class KubernetesDeploy extends FulfillableGoalWithRegistrations<Kubernete
  */
 export function initiateKubernetesDeploy(k8Deploy: KubernetesDeploy, registration: KubernetesDeployRegistration): ExecuteGoal {
     return async (goalInvocation: GoalInvocation): Promise<ExecuteGoalResult> => {
+        defaultDataSources(registration);
         const goalEvent = await generateKubernetesGoalEventData(k8Deploy, registration, goalInvocation);
         if (isInLocalMode()) {
             return deployApplication(goalEvent, goalInvocation.context, goalInvocation.progressLog);

--- a/lib/kubernetes/name.ts
+++ b/lib/kubernetes/name.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2019 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const defaultValidName = "valid-name";
+
+/**
+ * Ensure the provided name is a valid Kubernetes resouce name.  The
+ * validation regular expression for a resource is
+ * /^[a-z]([-a-z0-9]*[a-z0-9])?$/ and it must be between 1 and 63
+ * characters long.
+ *
+ * @param name The resource name
+ * @return A valid resource name based on the input
+ */
+export function validName(name: string): string {
+    const valid = name.slice(0, 63).toLocaleLowerCase()
+        .replace(/^[^a-z]+/, "")
+        .replace(/[^a-z0-9]+$/, "")
+        .replace(/[^-a-z0-9]+/g, "-");
+    return (valid) ? valid : defaultValidName;
+}

--- a/test/deploy/goal.test.ts
+++ b/test/deploy/goal.test.ts
@@ -1,0 +1,133 @@
+/*
+ * Copyright © 2019 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from "power-assert";
+import {
+    defaultDataSources,
+    KubernetesDeployDataSources,
+    KubernetesDeployRegistration,
+} from "../../lib/deploy/goal";
+
+describe("deploy/goal", () => {
+
+    describe("kubernetesGoalDataSources", () => {
+
+        it("should populate with all data sources", () => {
+            const r: KubernetesDeployRegistration = {};
+            const p = defaultDataSources(r);
+            const e = {
+                dataSources: [
+                    KubernetesDeployDataSources.DeploymentSpec,
+                    KubernetesDeployDataSources.Dockerfile,
+                    KubernetesDeployDataSources.GoalEvent,
+                    KubernetesDeployDataSources.IngressSpec,
+                    KubernetesDeployDataSources.RoleBindingSpec,
+                    KubernetesDeployDataSources.RoleSpec,
+                    KubernetesDeployDataSources.SdmConfiguration,
+                    KubernetesDeployDataSources.ServiceAccountSpec,
+                    KubernetesDeployDataSources.ServiceSpec,
+                ],
+            };
+            assert.deepStrictEqual(p, e);
+            assert.deepStrictEqual(r, e);
+        });
+
+        it("should populate and leave other data untouched", () => {
+            const r: KubernetesDeployRegistration = {
+                name: "gram",
+                pushTest: {
+                    name: "True",
+                } as any,
+            };
+            const p = defaultDataSources(r);
+            const e = {
+                name: "gram",
+                pushTest: {
+                    name: "True",
+                },
+                dataSources: [
+                    KubernetesDeployDataSources.DeploymentSpec,
+                    KubernetesDeployDataSources.Dockerfile,
+                    KubernetesDeployDataSources.GoalEvent,
+                    KubernetesDeployDataSources.IngressSpec,
+                    KubernetesDeployDataSources.RoleBindingSpec,
+                    KubernetesDeployDataSources.RoleSpec,
+                    KubernetesDeployDataSources.SdmConfiguration,
+                    KubernetesDeployDataSources.ServiceAccountSpec,
+                    KubernetesDeployDataSources.ServiceSpec,
+                ],
+            };
+            assert.deepStrictEqual(p, e);
+            assert.deepStrictEqual(r, e);
+        });
+
+        it("should leave it an empty array", () => {
+            const r: KubernetesDeployRegistration = { dataSources: [] };
+            const p = defaultDataSources(r);
+            const e: KubernetesDeployRegistration = { dataSources: [] };
+            assert.deepStrictEqual(p, e);
+            assert.deepStrictEqual(r, e);
+        });
+
+        it("should leave original data sources", () => {
+            const r: KubernetesDeployRegistration = {
+                dataSources: [
+                    KubernetesDeployDataSources.Dockerfile,
+                    KubernetesDeployDataSources.SdmConfiguration,
+                    KubernetesDeployDataSources.GoalEvent,
+                ],
+            };
+            const p = defaultDataSources(r);
+            const e = {
+                dataSources: [
+                    KubernetesDeployDataSources.Dockerfile,
+                    KubernetesDeployDataSources.SdmConfiguration,
+                    KubernetesDeployDataSources.GoalEvent,
+                ],
+            };
+            assert.deepStrictEqual(p, e);
+            assert.deepStrictEqual(r, e);
+        });
+
+        it("should leave everything alone", () => {
+            const r: KubernetesDeployRegistration = {
+                name: "gram",
+                dataSources: [
+                    KubernetesDeployDataSources.Dockerfile,
+                    KubernetesDeployDataSources.SdmConfiguration,
+                ],
+                pushTest: {
+                    name: "True",
+                } as any,
+            };
+            const p = defaultDataSources(r);
+            const e = {
+                name: "gram",
+                dataSources: [
+                    KubernetesDeployDataSources.Dockerfile,
+                    KubernetesDeployDataSources.SdmConfiguration,
+                ],
+                pushTest: {
+                    name: "True",
+                },
+            };
+            assert.deepStrictEqual(p, e);
+            assert.deepStrictEqual(r, e);
+        });
+
+    });
+
+});

--- a/test/kubernetes/name.test.ts
+++ b/test/kubernetes/name.test.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright © 2019 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from "power-assert";
+import {
+    defaultValidName,
+    validName,
+} from "../../lib/kubernetes/name";
+
+describe("kubernetes/name", () => {
+
+    describe("validName", () => {
+
+        const validation = /^[a-z]([-a-z0-9]*[a-z0-9])?$/;
+
+        it("should not change a valid name", () => {
+            const n = "kat3bu5h-cloudbusting5";
+            const v = validName(n);
+            assert(validation.test(v));
+            assert(n === v);
+        });
+
+        it("should return something valid when an empty string results", () => {
+            ["", "---", "01234", "___"].forEach(n => {
+                const v = validName(n);
+                assert(validation.test(v));
+                assert(v === defaultValidName);
+            });
+        });
+
+        it("should fix an invalid name", () => {
+            const n = "Kat3Bu5h_Cloudbusting5.";
+            const v = validName(n);
+            assert(validation.test(v));
+            const e = "kat3bu5h-cloudbusting5";
+            assert(v === e);
+        });
+
+        it("should truncate a long name", () => {
+            const n = "a234567891123456789212345678931234567894123456789512345678961234";
+            const v = validName(n);
+            assert(validation.test(v));
+            const e = "a23456789112345678921234567893123456789412345678951234567896123";
+            assert(v === e);
+        });
+
+        it("should properly truncate a complex long name", () => {
+            const n = "A23456789112345678921234567893_234567894123456789512345678961.?456789";
+            const v = validName(n);
+            assert(validation.test(v));
+            const e = "a23456789112345678921234567893-234567894123456789512345678961";
+            assert(v === e);
+        });
+
+    });
+
+});


### PR DESCRIPTION
Reorganize loading of Kubernetes application data from goal, event,
and project and make it configurable.

Closes #37

Ensure app name is a valid Kubernetes resource name.

Closes #42