### PR TITLE
Add Kubernetes fetch

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -25,9 +25,19 @@ export {
     k8sSupport,
 } from "./lib/k8s";
 export {
+    kubernetesFetch,
+    KubernetesFetchOptions,
+    KubernetesResourceKind,
+    KubernetesResourceSelector,
+} from "./lib/kubernetes/fetch";
+export {
     KubernetesApplication,
     KubernetesDelete,
 } from "./lib/kubernetes/request";
 export {
     encodeSecret,
 } from "./lib/kubernetes/secret";
+export {
+    kubernetesSpecFileBasename,
+    kubernetesSpecStringify,
+} from "./lib/kubernetes/spec";

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -55,7 +55,7 @@ export interface SyncRepoRef extends RepoRef {
 /**
  * Configuration options for sync mode operation.
  */
-export interface SyncOptions {
+export interface KubernetesSyncOptions {
     /**
      * To synchronize resources in k8s cluster with a Git repo,
      * provide a repo ref as the value of this property.  The value
@@ -114,10 +114,10 @@ export interface SdmPackK8sOptions {
     /**
      * Synchronize resources in k8s cluster with a Git repo.
      */
-    sync?: SyncOptions;
+    sync?: KubernetesSyncOptions;
 }
 
 /** Validate the the partial SyncOptions contains a repo property. */
-export function validSyncOptions(o: Partial<SyncOptions>): o is SyncOptions {
+export function validSyncOptions(o: Partial<KubernetesSyncOptions>): o is KubernetesSyncOptions {
     return !!o && !!o.repo;
 }

--- a/lib/kubernetes/api.ts
+++ b/lib/kubernetes/api.ts
@@ -28,7 +28,7 @@ export interface K8sObjectResponse {
 }
 
 export interface K8sListResponse {
-    body: k8s.KubernetesListObject;
+    body: k8s.KubernetesListObject<k8s.KubernetesObject>;
     response: http.IncomingMessage;
 }
 

--- a/lib/kubernetes/clients.ts
+++ b/lib/kubernetes/clients.ts
@@ -40,7 +40,7 @@ async function patchWithHeaders(api: any, patcher: any, args: any[]) {
     return returnValue;
 }
 
-class Core_v1Api_Patch extends k8s.Core_v1Api {
+class CoreV1ApiPatch extends k8s.CoreV1Api {
     patchNamespace(...args: any[]) {
         return patchWithHeaders(this, super.patchNamespace, args);
     }
@@ -55,19 +55,19 @@ class Core_v1Api_Patch extends k8s.Core_v1Api {
     }
 }
 
-class Apps_v1Api_Patch extends k8s.Apps_v1Api {
+class AppsV1ApiPatch extends k8s.AppsV1Api {
     patchNamespacedDeployment(...args: any[]) {
         return patchWithHeaders(this, super.patchNamespacedDeployment, args);
     }
 }
 
-class Extensions_v1beta1Api_Patch extends k8s.Extensions_v1beta1Api {
+class ExtensionsV1beta1ApiPatch extends k8s.ExtensionsV1beta1Api {
     patchNamespacedIngress(...args: any[]) {
         return patchWithHeaders(this, super.patchNamespacedIngress, args);
     }
 }
 
-class RbacAuthorization_v1Api_Patch extends k8s.RbacAuthorization_v1Api {
+class RbacAuthorizationV1ApiPatch extends k8s.RbacAuthorizationV1Api {
     patchClusterRole(...args: any[]) {
         return patchWithHeaders(this, super.patchClusterRole, args);
     }
@@ -89,26 +89,26 @@ class RbacAuthorization_v1Api_Patch extends k8s.RbacAuthorization_v1Api {
  */
 export interface KubernetesClients {
     /** Kubernetes Core client */
-    core: k8s.Core_v1Api;
+    core: k8s.CoreV1Api;
     /** Kubernetes Apps client, GA in Kubernetes 1.9 */
-    apps: k8s.Apps_v1Api;
+    apps: k8s.AppsV1Api;
     /** Kubernetes Extension client */
-    ext: k8s.Extensions_v1beta1Api;
+    ext: k8s.ExtensionsV1beta1Api;
     /** Kubernetes RBAC client, GA in Kubernetes 1.8 */
-    rbac: k8s.RbacAuthorization_v1Api;
+    rbac: k8s.RbacAuthorizationV1Api;
 }
 
 /**
  * Create the KubernetesClients structure.
  */
 export function makeApiClients(kc: k8s.KubeConfig): KubernetesClients {
-    // const core = kc.makeApiClient(k8s.Core_v1Api);
-    // const apps = kc.makeApiClient(k8s.Apps_v1Api);
-    // const rbac = kc.makeApiClient(k8s.RbacAuthorization_v1Api);
-    // const ext = kc.makeApiClient(k8s.Extensions_v1beta1Api);
-    const core = kc.makeApiClient(Core_v1Api_Patch);
-    const apps = kc.makeApiClient(Apps_v1Api_Patch);
-    const rbac = kc.makeApiClient(RbacAuthorization_v1Api_Patch);
-    const ext = kc.makeApiClient(Extensions_v1beta1Api_Patch);
+    // const core = kc.makeApiClient(k8s.CoreV1Api);
+    // const apps = kc.makeApiClient(k8s.AppsV1Api);
+    // const rbac = kc.makeApiClient(k8s.RbacAuthorizationV1Api);
+    // const ext = kc.makeApiClient(k8s.ExtensionsV1beta1Api);
+    const core = kc.makeApiClient(CoreV1ApiPatch);
+    const apps = kc.makeApiClient(AppsV1ApiPatch);
+    const rbac = kc.makeApiClient(RbacAuthorizationV1ApiPatch);
+    const ext = kc.makeApiClient(ExtensionsV1beta1ApiPatch);
     return { core, apps, rbac, ext };
 }

--- a/lib/kubernetes/fetch.ts
+++ b/lib/kubernetes/fetch.ts
@@ -1,0 +1,451 @@
+/*
+ * Copyright © 2019 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { logger } from "@atomist/automation-client";
+import * as k8s from "@kubernetes/client-node";
+import * as _ from "lodash";
+import { DeepPartial } from "ts-essentials";
+import { errMsg } from "../support/error";
+import {
+    isClusterResource,
+    K8sObject,
+    K8sObjectApi,
+} from "./api";
+import {
+    KubernetesClients,
+    makeApiClients,
+} from "./clients";
+import { loadKubeConfig } from "./config";
+import { labelMatch } from "./labels";
+import { nameMatch } from "./name";
+
+/** Kubernetes resource type specifier. */
+export interface KubernetesResourceKind {
+    /** Kubernetes API version, e.g., "v1" or "apps/v1". */
+    apiVersion: string;
+    /** Kubernetes resource, e.g., "Service" or "Deployment". */
+    kind: string;
+}
+
+/**
+ * Various ways to select Kubernetes resources.  All means provided
+ * are logically ANDed together.
+ */
+export interface KubernetesResourceSelector {
+    /**
+     * Whether this selector is for inclusion or exclusion.
+     * If not provided, the rule will be used for inclusion.
+     */
+    action?: "include" | "exclude";
+    /**
+     * If provided, only resources of a kind provided will be
+     * considered a match.  See [[populateResourceSelectorDefaults]] for
+     * rules on how it is populated if it is not set.
+     */
+    kinds?: KubernetesResourceKind[];
+    /**
+     * If provided, only resources with names matching either the
+     * entire string or regular expression will be considered a match.  If not
+     * provided, the resource name is not considered when matching.
+     */
+    name?: string | RegExp;
+    /**
+     * If provided, only resources in namespaces matching either the
+     * entire strings or regular expression will be considered a match.  If not
+     * provided, the resource namespace is not considered when
+     * matching.
+     */
+    namespace?: string | RegExp;
+    /**
+     * Kubernetes-style label selectors.  If provided, only resources
+     * matching the selectors are considered a match.  If not provided, the
+     * resource labels are not considered when matching.
+     */
+    labelSelector?: DeepPartial<k8s.V1LabelSelector>;
+    /**
+     * If provided, resources will be considered a match if their
+     * filter function returns `true`.   If not provided, this property
+     * has no effect on matching.
+     */
+    filter?: (r: K8sObject) => boolean;
+}
+
+/**
+ * Useful default set of kinds of Kubernetes resources.
+ */
+export const defaultKubernetesResourceSelectorKinds: KubernetesResourceKind[] = [
+    { apiVersion: "v1", kind: "ConfigMap" },
+    { apiVersion: "v1", kind: "Secret" },
+    { apiVersion: "v1", kind: "Service" },
+    { apiVersion: "v1", kind: "ServiceAccount" },
+    { apiVersion: "v1", kind: "PersistentVolume" },
+    { apiVersion: "v1", kind: "PersistentVolumeClaim" },
+    { apiVersion: "extensions/v1beta1", kind: "Ingress" },
+    { apiVersion: "extensions/v1beta1", kind: "PodSecurityPolicy" },
+    { apiVersion: "apps/v1", kind: "DaemonSet" },
+    { apiVersion: "apps/v1", kind: "Deployment" },
+    { apiVersion: "apps/v1", kind: "StatefulSet" },
+    { apiVersion: "autoscaling/v1", kind: "HorizontalPodAutoscaler" },
+    { apiVersion: "batch/v1beta1", kind: "CronJob" },
+    { apiVersion: "networking.k8s.io/v1", kind: "NetworkPolicy" },
+    { apiVersion: "policy/v1beta1", kind: "PodDisruptionBudget" },
+    { apiVersion: "rbac.authorization.k8s.io/v1", kind: "ClusterRole" },
+    { apiVersion: "rbac.authorization.k8s.io/v1", kind: "ClusterRoleBinding" },
+    { apiVersion: "rbac.authorization.k8s.io/v1", kind: "Role" },
+    { apiVersion: "rbac.authorization.k8s.io/v1", kind: "RoleBinding" },
+    { apiVersion: "storage.k8s.io/v1", kind: "StorageClass" },
+];
+
+/**
+ * Kubernetes fetch options specifying which resources to fetch.
+ */
+export interface KubernetesFetchOptions {
+    /**
+     * Array of Kubernetes resource selectors.  The selectors are
+     * applied in order to each resource and the action of the first
+     * matching selector is applied.
+     */
+    selectors?: KubernetesResourceSelector[];
+}
+
+/**
+ * The default options used when fetching resource from a Kubernetes
+ * cluster.  By default it fetches resources whose kind is in the
+ * [[defaultKubernetesResourceSelectorKinds]] array, excluding the
+ * resources that look like Kubernetes managed resources like the
+ * `kubernetes` service in the `default` namespace, resources in
+ * namespaces that starts with "kube-", and system- and cloud-related
+ * cluster roles and cluster role bindings.
+ */
+export const defaultKubernetesFetchOptions: KubernetesFetchOptions = {
+    selectors: [
+        { action: "exclude", namespace: /^kube-/ },
+        { action: "exclude", name: /^(?:kubeadm|system):/ },
+        { action: "exclude", kinds: [{ apiVersion: "v1", kind: "Service" }], namespace: "default", name: "kubernetes" },
+        { action: "exclude", kinds: [{ apiVersion: "v1", kind: "ServiceAccount" }], name: "default" },
+        {
+            action: "exclude",
+            kinds: [{ apiVersion: "rbac.authorization.k8s.io", kind: "ClusterRole" }],
+            name: /^(?:(?:cluster-)?admin|edit|view|cloud-provider)$/,
+        },
+        {
+            action: "exclude",
+            kinds: [{ apiVersion: "rbac.authorization.k8s.io", kind: "ClusterRoleBinding" }],
+            name: /^(?:cluster-admin(?:-binding)?|cloud-provider|kubernetes-dashboard)$/,
+        },
+        { action: "exclude", kinds: [{ apiVersion: "storage.k8s.io/v1", kind: "StorageClass" }], name: "standard" },
+        { action: "exclude", filter: (r: any) => r.kind === "Secret" && r.type === "kubernetes.io/service-account-token" },
+        { action: "exclude", filter: r => /^ClusterRole/.test(r.kind) && /(?:kubelet|:)/.test(r.metadata.name) },
+        { action: "include", kinds: defaultKubernetesResourceSelectorKinds },
+    ],
+};
+
+/**
+ * Fetch resource specs from a Kubernetes cluster as directed by the
+ * fetch options, removing read-only properties filled by the
+ * Kubernetes system.
+ *
+ * The inclusion selectors are processed to determine which resources
+ * in the Kubernetes cluster to query.
+ *
+ * @param options Kubernetes fetch options
+ * @return Kubernetes resources matching the fetch options
+ */
+export async function kubernetesFetch(options: KubernetesFetchOptions = defaultKubernetesFetchOptions): Promise<K8sObject[]> {
+    let client: K8sObjectApi;
+    let clients: KubernetesClients;
+    try {
+        const kc = loadKubeConfig();
+        client = kc.makeApiClient(K8sObjectApi);
+        clients = makeApiClients(kc);
+    } catch (e) {
+        e.message = `Failed to create Kubernetes client: ${errMsg(e)}`;
+        logger.error(e.message);
+        throw e;
+    }
+
+    const selectors = populateResourceSelectorDefaults(options.selectors);
+    const clusterResources = clusterResourceKinds(selectors);
+    const specs: K8sObject[] = [];
+
+    for (const apiKind of clusterResources) {
+        try {
+            const obj = apiObject(apiKind);
+            const listResponse = await client.list(obj);
+            specs.push(...listResponse.body.items.map(s => cleanKubernetesSpec(s, apiKind)));
+        } catch (e) {
+            e.message = `Failed to list cluster resources ${apiKind.apiVersion}/${apiKind.kind}: ${e.message}`;
+            logger.error(e.message);
+            throw e;
+        }
+    }
+
+    let namespaces: string[];
+    try {
+        const nsResponse = await clients.core.listNamespace();
+        namespaces = nsResponse.body.items.map((ns: K8sObject) => ns.metadata.name);
+    } catch (e) {
+        e.message = `Failed to list namespaces: ${e.message}`;
+        logger.error(e.message);
+        throw e;
+    }
+    for (const ns of namespaces) {
+        const apiKinds = namespaceResourceKinds(ns, selectors);
+        for (const apiKind of apiKinds) {
+            try {
+                const obj = apiObject(apiKind, ns);
+                const listResponse = await client.list(obj);
+                specs.push(...listResponse.body.items.map(s => cleanKubernetesSpec(s, apiKind)));
+            } catch (e) {
+                e.message = `Failed to list resources ${apiKind.apiVersion}/${apiKind.kind} in namespace ${ns}: ${e.message}`;
+                logger.error(e.message);
+                throw e;
+            }
+        }
+    }
+
+    return selectKubernetesResources(specs, selectors);
+}
+
+/**
+ * Make sure Kubernetes resource selectors have appropriate properties
+ * populated with default values.  If the selector does not have an
+ * `action` set, it is set to "include".  If the selector does not have
+ * `kinds` set and `action` is "include", `kinds` is set to
+ * [[defaultKubernetesResourceSelectorKinds]].  Rules with `action` set
+ * to "exclude" and have no selectors are discarded.
+ *
+ * @param selectors Kubernetes resource selectors to ensure have default values
+ * @return Properly defaulted Kubernetes resource selectors
+ */
+export function populateResourceSelectorDefaults(selectors: KubernetesResourceSelector[]): KubernetesResourceSelector[] {
+    return selectors.map(s => {
+        const k: KubernetesResourceSelector = { action: "include", ...s };
+        if (!k.kinds && k.action === "include") {
+            k.kinds = defaultKubernetesResourceSelectorKinds;
+        }
+        return k;
+    }).filter(s => s.action === "include" || s.filter || s.kinds || s.labelSelector || s.name || s.namespace);
+}
+
+/**
+ * Determine all Kuberenetes cluster, i.e., not namespaced, resources
+ * that we should query based on all the selectors and return an array
+ * with each Kubernetes cluster resource type appearing no more than
+ * once.  Note that uniqueness of a Kubernetes resource type is
+ * determined solely by the `kind` property, `apiVersion` is not
+ * considered since the same resource can be found with the same kind
+ * and different API versions.
+ *
+ * @param selectors All the resource selectors
+ * @return A deduplicated array of Kubernetes cluster resource kinds among the inclusion rules
+ */
+export function clusterResourceKinds(selectors: KubernetesResourceSelector[]): KubernetesResourceKind[] {
+    const included = includedResourceKinds(selectors);
+    return included.filter(ak => isClusterResource("list", ak.kind));
+}
+
+/**
+ * Determine all Kuberenetes resources that we should query based on
+ * all the selectors and return an array with each Kubernetes resource
+ * type appearing no more than once.  Note that uniqueness of a
+ * Kubernetes resource type is determined solely by the `kind`
+ * property, `apiVersion` is not considered since the same resource
+ * can be found with the same kind and different API versions.
+ *
+ * @param selectors All the resource selectors
+ * @return A deduplicated array of Kubernetes resource kinds among the inclusion rules
+ */
+export function includedResourceKinds(selectors: KubernetesResourceSelector[]): KubernetesResourceKind[] {
+    const includeSelectors = selectors.filter(s => s.action === "include");
+    const includeKinds = _.flatten(includeSelectors.map(s => s.kinds));
+    const uniqueKinds = _.uniqBy(includeKinds, "kind");
+    return uniqueKinds;
+}
+
+/**
+ * For the provided set of selectors, return a deduplicated array of
+ * resource kinds, using the same logic as [[includedResourceKinds]].
+ *
+ * @param ns Namespace to check
+ * @param selectors Selectors to evaluate
+ * @return A deduplicated array of Kubernetes resource kinds among the inclusion rules for namespace `ns`
+ */
+export function namespaceResourceKinds(ns: string, selectors: KubernetesResourceSelector[]): KubernetesResourceKind[] {
+    const apiKinds: KubernetesResourceKind[] = [];
+    for (const selector of selectors.filter(s => s.action === "include")) {
+        if (nameMatch(ns, selector.namespace)) {
+            apiKinds.push(...selector.kinds.filter(ak => !isClusterResource("list", ak.kind)));
+        }
+    }
+    return _.uniqBy(apiKinds, "kind");
+}
+
+/**
+ * Construct Kubernetes resource object for use with client API.
+ */
+function apiObject(apiKind: KubernetesResourceKind, ns?: string): K8sObject {
+    const ko: K8sObject = {
+        apiVersion: apiKind.apiVersion,
+        kind: apiKind.kind,
+    };
+    if (ns) {
+        ko.metadata = { namespace: ns };
+    }
+    return ko;
+}
+
+/**
+ * Remove read-only type properties not useful to retain in a resource
+ * specification used for upserting resources.  This is probably not
+ * perfect.  Add the `apiVersion` and `kind` properties since the they
+ * are not included in the items returned by the list endpoint,
+ * https://github.com/kubernetes/kubernetes/issues/3030 .
+ *
+ * @param obj Kubernetes spec to clean
+ * @return Kubernetes spec with status-like properties removed
+ */
+export function cleanKubernetesSpec(obj: k8s.KubernetesObject, apiKind: KubernetesResourceKind): K8sObject {
+    if (!obj) {
+        return obj;
+    }
+    const spec: any = { ...apiKind, ...obj };
+    if (spec.metadata) {
+        delete spec.metadata.creationTimestamp;
+        delete spec.metadata.generation;
+        delete spec.metadata.resourceVersion;
+        delete spec.metadata.selfLink;
+        delete spec.metadata.uid;
+        if (spec.metadata.annotations) {
+            delete spec.metadata.annotations["deployment.kubernetes.io/revision"];
+            delete spec.metadata.annotations["kubectl.kubernetes.io/last-applied-configuration"];
+            if (Object.keys(spec.metadata.annotations).length < 1) {
+                delete spec.metadata.annotations;
+            }
+        }
+    }
+    if (spec.spec && spec.spec.template && spec.spec.template.metadata) {
+        delete spec.spec.template.metadata.creationTimestamp;
+    }
+    delete spec.status;
+    return spec;
+}
+
+/**
+ * Filter provided Kubernetes resources according to the provides
+ * selectors.  Each selector is applied in turn to each spec.  The
+ * action of the first selector that matches a resource is applied to
+ * that resource.  If no selector matches a resource, it is not
+ * returned, i.e., the default is to exclude.
+ *
+ * @param specs Kubernetes resources to filter
+ * @param selectors Filtering rules
+ * @return Filtered array of Kubernetes resources
+ */
+export function selectKubernetesResources(specs: K8sObject[], selectors: KubernetesResourceSelector[]): K8sObject[] {
+    const uniqueSpecs = _.uniqBy(specs, kubernetesResourceIdentity);
+    if (!selectors || selectors.length < 1) {
+        return uniqueSpecs;
+    }
+    const filteredSpecs: K8sObject[] = [];
+    for (const spec of uniqueSpecs) {
+        for (const selector of selectors) {
+            const action = selectorMatch(spec, selector);
+            if (action === "include") {
+                filteredSpecs.push(spec);
+                break;
+            } else if (action === "exclude") {
+                break;
+            }
+        }
+    }
+    return filteredSpecs;
+}
+
+/**
+ * Reduce a Kubernetes resource to its uniquely identifying
+ * properties.  Note that `apiVersion` is not among them as identical
+ * resources can be access via different API versions, e.g.,
+ * Deployment via app/v1 and extensions/v1beta1.
+ *
+ * @param obj Kubernetes resource
+ * @return Stripped down resource for unique identification
+ */
+export function kubernetesResourceIdentity(obj: K8sObject): string {
+    return `${obj.kind}|` + (obj.metadata.namespace ? `${obj.metadata.namespace}|` : "") + obj.metadata.name;
+}
+
+/**
+ * Determine if Kubernetes resource is a match against the selector.
+ * If there is a match, return the action of the selector.  If there
+ * is not a match, return `undefined`.
+ *
+ * @param spec Kubernetes resource to check
+ * @param selector Selector to use for checking
+ * @return Selector action if there is a match, `undefined` otherwise
+ */
+export function selectorMatch(spec: K8sObject, selector: KubernetesResourceSelector): "include" | "exclude" | undefined {
+    if (!nameMatch(spec.metadata.name, selector.name)) {
+        return undefined;
+    }
+    if (!nameMatch(spec.metadata.namespace, selector.namespace)) {
+        return undefined;
+    }
+    if (!labelMatch(spec, selector.labelSelector)) {
+        return undefined;
+    }
+    if (!kindMatch(spec, selector.kinds)) {
+        return undefined;
+    }
+    if (!filterMatch(spec, selector.filter)) {
+        return undefined;
+    }
+    return selector.action;
+}
+
+/**
+ * Determine if Kubernetes resource `kind` property is among the kinds
+ * provided.  If no kinds are provided, it is considered matching.
+ * Only the resource's `kind` property is considered when matching,
+ * `apiVersion` is ignored.
+ *
+ * @param spec Kubernetes resource to check
+ * @param kinds Kubernetes resource selector `kinds` property to use for checking
+ * @return Return `true` if it is a match, `false` otherwise
+ */
+export function kindMatch(spec: K8sObject, kinds: KubernetesResourceKind[]): boolean {
+    if (!kinds || kinds.length < 1) {
+        return true;
+    }
+    return kinds.map(ak => ak.kind).includes(spec.kind);
+}
+
+/**
+ * Determine if Kubernetes resource `kind` property is among the kinds
+ * provided.  If no kinds are provided, it is considered matching.
+ * Only the resource's `kind` property is considered when matching,
+ * `apiVersion` is ignored.
+ *
+ * @param spec Kubernetes resource to check
+ * @param kinds Kubernetes resource selector `kinds` property to use for checking
+ * @return Return `true` if it is a match, `false` otherwise
+ */
+export function filterMatch(spec: K8sObject, filter: (r: K8sObject) => boolean): boolean {
+    if (!filter) {
+        return true;
+    }
+    return filter(spec);
+}

--- a/lib/kubernetes/name.ts
+++ b/lib/kubernetes/name.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import * as stringify from "json-stringify-safe";
+
 /**
  * If removing invalid characters from the name results in an empty
  * string, this value is used as the name.  You do not want more than
@@ -36,4 +38,28 @@ export function validName(name: string): string {
         .replace(/[^a-z0-9]+$/, "")
         .replace(/[^-a-z0-9]+/g, "-");
     return (valid) ? valid : defaultValidName;
+}
+
+/**
+ * Determine if the `value` matches the `matcher`.
+ * The matching rules are as follows:
+ *
+ * -   If the `matcher` is a string, `value` and `matcher` must be equal (===).
+ * -   If `matcher` is a regular expression, `value` must match the regular expression according to RegExp.test().
+ * -   If no `matcher` is provided, any `value` matches.
+ *
+ * @param value String to match
+ * @param matcher String or RegExp to match against
+ * @return `true` if it is a match, `false` otherwise
+ */
+export function nameMatch(value: string, matcher?: string | RegExp): boolean {
+    if (typeof matcher === "string") {
+        return matcher === value;
+    } else if (matcher instanceof RegExp) {
+        return matcher.test(value);
+    } else if (!matcher) {
+        return true;
+    } else {
+        throw new Error(`Provided matcher is neither a string or RegExp: ${stringify(matcher)}: ${typeof matcher}`);
+    }
 }

--- a/lib/kubernetes/secret.ts
+++ b/lib/kubernetes/secret.ts
@@ -146,27 +146,32 @@ export function encodeSecret(name: string, data: { [key: string]: string }): k8s
 }
 
 /**
- * Encrypt secret values, which should already be base64 encoded.
+ * Return a copy of the provided secret with its data values
+ * encrypted.  The provided secret should have its data values base64
+ * encoded.  The provided secret is not modified.
  *
  * @param secret Kubernetes secret with base64 encoded data values
  * @return Kubernetes secret object with encrypted data values
  */
 export async function encryptSecret(secret: DeepPartial<k8s.V1Secret>, key: string): Promise<k8s.V1Secret> {
+    const encrypted = _.cloneDeep(secret);
     for (const datum of Object.keys(secret.data)) {
-        secret.data[datum] = await encrypt(secret.data[datum], key);
+        encrypted.data[datum] = await encrypt(secret.data[datum], key);
     }
-    return secret as k8s.V1Secret;
+    return encrypted as k8s.V1Secret;
 }
 
 /**
- * Dencrypt secret values.
+ * Return a copy of the provided secret with its data valued
+ * decrypted.  The provided secret is not modified.
  *
  * @param secret Kubernetes secret with encrypted data values
  * @return Kubernetes secret object with base64 encoded data values
  */
 export async function decryptSecret(secret: DeepPartial<k8s.V1Secret>, key: string): Promise<k8s.V1Secret> {
+    const decrypted = _.cloneDeep(secret);
     for (const datum of Object.keys(secret.data)) {
-        secret.data[datum] = await decrypt(secret.data[datum], key);
+        decrypted.data[datum] = await decrypt(secret.data[datum], key);
     }
-    return secret as k8s.V1Secret;
+    return decrypted as k8s.V1Secret;
 }

--- a/lib/kubernetes/spec.ts
+++ b/lib/kubernetes/spec.ts
@@ -1,0 +1,122 @@
+/*
+ * Copyright © 2019 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as yaml from "js-yaml";
+import * as stableStringify from "json-stable-stringify";
+import { K8sObject } from "./api";
+import { encryptSecret } from "./secret";
+
+/**
+ * Create a suitable basename for the spec file for `resource`.  The
+ * form of the file name is "NN-NAMESPACE-NAME-KIND", where "NN" is a
+ * numeric prefix so the resources are created in the proper order,
+ * "NAMESPACE-" is omitted if resource is not namespaced, the kind is
+ * converted from PascalCase to kebab-case, and the whole name is
+ * lowercased.
+ *
+ * @param resource Kubernetes resource spec
+ * @return Base file name for resource spec
+ */
+export function kubernetesSpecFileBasename(resource: K8sObject): string {
+    let prefix: string;
+    switch (resource.kind) {
+        case "Namespace":
+            prefix = "10";
+            break;
+        case "PersistentVolume":
+        case "StorageClass":
+            prefix = "15";
+            break;
+        case "ServiceAccount":
+            prefix = "20";
+            break;
+        case "ClusterRole":
+        case "Role":
+            prefix = "25";
+            break;
+        case "ClusterRoleBinding":
+        case "RoleBinding":
+            prefix = "30";
+            break;
+        case "NetworkPolicy":
+        case "PersistentVolumeClaim":
+        case "PodSecurityPolicy":
+            prefix = "40";
+            break;
+        case "Service":
+            prefix = "50";
+            break;
+        case "ConfigMap":
+        case "Secret":
+            prefix = "60";
+            break;
+        case "CronJob":
+        case "DaemonSet":
+        case "Deployment":
+        case "StatefulSet":
+            prefix = "70";
+            break;
+        case "HorizontalPodAutoscaler":
+        case "Ingress":
+        case "PodDisruptionBudget":
+            prefix = "80";
+            break;
+        default:
+            prefix = "90";
+            break;
+    }
+    const ns = (resource.metadata.namespace) ? `${resource.metadata.namespace}_` : "";
+    const kebabKind = resource.kind.replace(/([a-z])([A-Z])/g, "$1-$2");
+    return `${prefix}_${ns}${resource.metadata.name}_${kebabKind}`.toLowerCase();
+}
+
+/**
+ * Options for creating a string representation of a Kubernetes
+ * resource specification.
+ */
+export interface KubernetesSpecStringifyOptions {
+    /**
+     * Serialization format, either "json" or "yaml".  The default is
+     * "json".
+     */
+    format?: "json" | "yaml";
+    /**
+     * The key to use to encrypt v1/Secret data values.  See
+     * [[encryptSecret]] for details.  If no value is provided, the
+     * secret data values are not encrypted.
+     */
+    secretKey?: string;
+}
+
+/**
+ * Convert a Kubernetes resource spec into a stable string suitable
+ * for writing to a file or comparisons.
+ *
+ * @param resource Kubernetes resource to stringify
+ * @param options Options for serializing the resource spec
+ * @return Stable string representation of the resource spec
+ */
+export async function kubernetesSpecStringify(spec: K8sObject, options: KubernetesSpecStringifyOptions = {}): Promise<string> {
+    let resource = spec;
+    if (resource.kind === "Secret" && options.secretKey) {
+        resource = await encryptSecret(resource, options.secretKey);
+    }
+    if (options.format === "yaml") {
+        return yaml.safeDump(resource, { sortKeys: true });
+    } else {
+        return stableStringify(resource, { space: 2 }) + "\n";
+    }
+}

--- a/lib/sync/change.ts
+++ b/lib/sync/change.ts
@@ -21,7 +21,7 @@ import {
 } from "@atomist/automation-client";
 import { execPromise } from "@atomist/sdm";
 import * as _ from "lodash";
-import { SyncOptions } from "../config";
+import { KubernetesSyncOptions } from "../config";
 import { parseKubernetesSpecString } from "../deploy/spec";
 import { K8sObject } from "../kubernetes/api";
 import { applySpec } from "../kubernetes/apply";
@@ -62,7 +62,7 @@ export async function changeResource(p: GitProject, change: PushDiff): Promise<v
     }
 
     if (change.change !== "delete" && spec.kind === "Secret") {
-        const syncOpts = configurationValue<Partial<SyncOptions>>("sdm.k8s.options.sync", {});
+        const syncOpts = configurationValue<Partial<KubernetesSyncOptions>>("sdm.k8s.options.sync", {});
         if (syncOpts.secretKey) {
             spec = await decryptSecret(spec, syncOpts.secretKey);
         }

--- a/lib/sync/goals.ts
+++ b/lib/sync/goals.ts
@@ -30,14 +30,14 @@ import {
     whenPushSatisfies,
 } from "@atomist/sdm";
 import * as _ from "lodash";
-import { SyncOptions } from "../config";
+import { KubernetesSyncOptions } from "../config";
 import { errMsg } from "../support/error";
 import { changeResource } from "./change";
 import { diffPush } from "./diff";
 import { commitTag } from "./tag";
 
 export function isSyncRepoCommit(sdm: SoftwareDeliveryMachine): PushTest | undefined {
-    const syncOptions: SyncOptions = _.get(sdm, "configuration.sdm.k8s.options.sync");
+    const syncOptions: KubernetesSyncOptions = _.get(sdm, "configuration.sdm.k8s.options.sync");
     if (!syncOptions || !syncOptions.repo) {
         logger.debug(`SDM configuration contains no sync repo, will not create sync repo push test`);
         return undefined;

--- a/lib/sync/repo.ts
+++ b/lib/sync/repo.ts
@@ -27,7 +27,7 @@ import { SoftwareDeliveryMachine } from "@atomist/sdm";
 import * as stringify from "json-stringify-safe";
 import * as _ from "lodash";
 import {
-    SyncOptions,
+    KubernetesSyncOptions,
     SyncRepoRef,
 } from "../config";
 import {
@@ -70,7 +70,7 @@ const defaultDefaultBranch = "master";
  * @return true if sync options set and repo found or false and sync options deleted
  */
 export async function queryForScmProvider(sdm: SoftwareDeliveryMachine): Promise<boolean> {
-    const syncOptions: SyncOptions = _.get(sdm, "configuration.sdm.k8s.options.sync");
+    const syncOptions: KubernetesSyncOptions = _.get(sdm, "configuration.sdm.k8s.options.sync");
     if (!syncOptions) {
         logger.info(`SDM configuration contains no sync repo`);
         return false;

--- a/lib/sync/startup.ts
+++ b/lib/sync/startup.ts
@@ -27,7 +27,7 @@ import {
 import { isInLocalMode } from "@atomist/sdm-core";
 import * as cluster from "cluster";
 import * as _ from "lodash";
-import { SyncOptions } from "../config";
+import { KubernetesSyncOptions } from "../config";
 import { parseKubernetesSpecFile } from "../deploy/spec";
 import { applySpec } from "../kubernetes/apply";
 import { decryptSecret } from "../kubernetes/secret";
@@ -67,7 +67,7 @@ export const syncRepoStartupListener: StartupListener = async ctx => {
         id: sdm.configuration.sdm.k8s.options.sync.repo,
         readOnly: true,
     };
-    const opts: SyncOptions = _.get(sdm, "configuration.sdm.k8s.options.sync");
+    const opts: KubernetesSyncOptions = _.get(sdm, "configuration.sdm.k8s.options.sync");
     try {
         await sdm.configuration.sdm.projectLoader.doWithProject(projectLoadingParameters, initialSync(opts));
     } catch (e) {
@@ -92,7 +92,7 @@ export const syncRepoStartupListener: StartupListener = async ctx => {
  *
  * @param syncRepo Repository of specs to sync
  */
-function initialSync(opts: SyncOptions): (p: GitProject) => Promise<void> {
+function initialSync(opts: KubernetesSyncOptions): (p: GitProject) => Promise<void> {
     return async syncRepo => {
         const specFiles = await sortSpecs(syncRepo);
         const errors: Error[] = [];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomist/sdm-pack-k8s",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -543,19 +543,19 @@
       }
     },
     "@kubernetes/client-node": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/@kubernetes/client-node/-/client-node-0.8.2.tgz",
-      "integrity": "sha512-crS3h59+fOGXQgxVdq3XH81ytY7FV2HnB5z/+lSWD3bi5D5lHKu3PVN2PHCDMNExPy0KthcfqBoIVFVy4CoG3A==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@kubernetes/client-node/-/client-node-0.10.2.tgz",
+      "integrity": "sha512-JvsmxbTwiMqsh9LyuXMzT5HjoENFbB3a/JroJsobuAzkxN162UqAOvg++/AA+ccIMWRR2Qln4FyaOJ0a4eKyXg==",
       "requires": {
-        "@types/js-yaml": "^3.11.2",
+        "@types/js-yaml": "^3.12.1",
         "@types/node": "^10.12.0",
         "@types/request": "^2.47.1",
         "@types/underscore": "^1.8.9",
         "@types/ws": "^6.0.1",
-        "byline": "^5.0.0",
         "isomorphic-ws": "^4.0.1",
-        "js-yaml": "^3.12.0",
-        "jsonpath": "^1.0.0",
+        "js-yaml": "^3.13.1",
+        "json-stream": "^1.0.0",
+        "jsonpath-plus": "^0.19.0",
         "request": "^2.88.0",
         "shelljs": "^0.8.2",
         "tslib": "^1.9.3",
@@ -2482,7 +2482,8 @@
     "byline": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
-      "integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE="
+      "integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE=",
+      "dev": true
     },
     "bytes": {
       "version": "3.1.0",
@@ -3335,7 +3336,8 @@
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
     },
     "deepmerge": {
       "version": "4.0.0",
@@ -3801,6 +3803,7 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.1.tgz",
       "integrity": "sha512-JwiqFD9KdGVVpeuRa68yU3zZnBEOcPs0nKW7wZzXky8Z7tffdYUHbe11bPCV5jYlK6DVdKLWLm0f5I/QlL0Kmw==",
+      "dev": true,
       "requires": {
         "esprima": "^3.1.3",
         "estraverse": "^4.2.0",
@@ -3812,7 +3815,8 @@
         "esprima": {
           "version": "3.1.3",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
-          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
+          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+          "dev": true
         }
       }
     },
@@ -3938,12 +3942,14 @@
     "estraverse": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+      "dev": true
     },
     "esutils": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true
     },
     "etag": {
       "version": "1.8.1",
@@ -4297,7 +4303,8 @@
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
     },
     "fast-safe-stringify": {
       "version": "2.0.6",
@@ -6591,8 +6598,7 @@
     "json-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-stream/-/json-stream-1.0.0.tgz",
-      "integrity": "sha1-GjhU4o0rvuqzHMfd9oPS3cVlJwg=",
-      "dev": true
+      "integrity": "sha1-GjhU4o0rvuqzHMfd9oPS3cVlJwg="
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -6623,33 +6629,10 @@
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
     },
-    "jsonpath": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/jsonpath/-/jsonpath-1.0.2.tgz",
-      "integrity": "sha512-rmzlgFZiQPc6q4HDyK8s9Qb4oxBnI5sF61y/Co5PV0lc3q2bIuRsNdueVbhoSHdKM4fxeimphOAtfz47yjCfeA==",
-      "requires": {
-        "esprima": "1.2.2",
-        "static-eval": "2.0.2",
-        "underscore": "1.7.0"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "1.2.2",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.2.tgz",
-          "integrity": "sha1-dqD9Zvz+FU/SkmZ9wmQBl1CxZXs="
-        },
-        "underscore": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
-          "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk="
-        }
-      }
-    },
     "jsonpath-plus": {
       "version": "0.19.0",
       "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-0.19.0.tgz",
-      "integrity": "sha512-GSVwsrzW9LsA5lzsqe4CkuZ9wp+kxBb2GwNniaWzI2YFn5Ig42rSW8ZxVpWXaAfakXNrx5pgY5AbQq7kzX29kg==",
-      "dev": true
+      "integrity": "sha512-GSVwsrzW9LsA5lzsqe4CkuZ9wp+kxBb2GwNniaWzI2YFn5Ig42rSW8ZxVpWXaAfakXNrx5pgY5AbQq7kzX29kg=="
     },
     "jsprim": {
       "version": "1.4.1",
@@ -6699,6 +6682,7 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
       "requires": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
@@ -7895,6 +7879,7 @@
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "dev": true,
       "requires": {
         "deep-is": "~0.1.3",
         "fast-levenshtein": "~2.0.4",
@@ -8442,7 +8427,8 @@
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
     },
     "prepend-http": {
       "version": "2.0.0",
@@ -9295,7 +9281,8 @@
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
     },
     "source-map-resolve": {
       "version": "0.5.2",
@@ -9402,14 +9389,6 @@
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
       "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
       "dev": true
-    },
-    "static-eval": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.0.2.tgz",
-      "integrity": "sha512-N/D219Hcr2bPjLxPiV+TQE++Tsmrady7TqAJugLy7Xk1EumfDWS/f5dtBbkRCGE7wKKXuYockQoj8Rm2/pVKyg==",
-      "requires": {
-        "escodegen": "^1.8.1"
-      }
     },
     "static-extend": {
       "version": "0.1.2",
@@ -9992,6 +9971,7 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
       "requires": {
         "prelude-ls": "~1.1.2"
       }
@@ -10498,7 +10478,8 @@
     "wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
     },
     "wrap-ansi": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomist/sdm-pack-k8s",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "description": "Extension Pack for an Atomist SDM to integrate Kubernetes deployments",
   "author": {
     "name": "Atomist",
@@ -27,7 +27,7 @@
   "main": "./index.js",
   "types": "./index.d.ts",
   "dependencies": {
-    "@kubernetes/client-node": "^0.8.2",
+    "@kubernetes/client-node": "^0.10.2",
     "@types/js-yaml": "^3.11.4",
     "@types/json-stable-stringify": "^1.0.32",
     "@types/json-stringify-safe": "^5.0.0",

--- a/test/kubernetes/fetch.test.ts
+++ b/test/kubernetes/fetch.test.ts
@@ -1,0 +1,1336 @@
+/*
+ * Copyright © 2019 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { execPromise } from "@atomist/sdm";
+import * as k8s from "@kubernetes/client-node";
+import * as _ from "lodash";
+import * as assert from "power-assert";
+import { DeepPartial } from "ts-essentials";
+import { K8sObject } from "../../lib/kubernetes/api";
+import {
+    cleanKubernetesSpec,
+    clusterResourceKinds,
+    defaultKubernetesFetchOptions,
+    defaultKubernetesResourceSelectorKinds,
+    filterMatch,
+    includedResourceKinds,
+    kindMatch,
+    kubernetesFetch,
+    kubernetesResourceIdentity,
+    KubernetesResourceSelector,
+    namespaceResourceKinds,
+    populateResourceSelectorDefaults,
+    selectKubernetesResources,
+    selectorMatch,
+} from "../../lib/kubernetes/fetch";
+import { DefaultLogRetryOptions } from "../../lib/support/retry";
+
+/* tslint:disable:max-file-line-count */
+
+describe("kubernetes/fetch", () => {
+
+    describe("populateResourceSelectorDefaults", () => {
+
+        it("should do nothing successfully", () => {
+            const p = populateResourceSelectorDefaults([]);
+            assert.deepStrictEqual(p, []);
+        });
+
+        it("should populate an empty object", () => {
+            const s = [{}];
+            const p = populateResourceSelectorDefaults(s);
+            const e = [
+                {
+                    action: "include",
+                    kinds: [
+                        { apiVersion: "v1", kind: "ConfigMap" },
+                        { apiVersion: "v1", kind: "Secret" },
+                        { apiVersion: "v1", kind: "Service" },
+                        { apiVersion: "v1", kind: "ServiceAccount" },
+                        { apiVersion: "v1", kind: "PersistentVolume" },
+                        { apiVersion: "v1", kind: "PersistentVolumeClaim" },
+                        { apiVersion: "extensions/v1beta1", kind: "Ingress" },
+                        { apiVersion: "extensions/v1beta1", kind: "PodSecurityPolicy" },
+                        { apiVersion: "apps/v1", kind: "DaemonSet" },
+                        { apiVersion: "apps/v1", kind: "Deployment" },
+                        { apiVersion: "apps/v1", kind: "StatefulSet" },
+                        { apiVersion: "autoscaling/v1", kind: "HorizontalPodAutoscaler" },
+                        { apiVersion: "batch/v1beta1", kind: "CronJob" },
+                        { apiVersion: "networking.k8s.io/v1", kind: "NetworkPolicy" },
+                        { apiVersion: "policy/v1beta1", kind: "PodDisruptionBudget" },
+                        { apiVersion: "rbac.authorization.k8s.io/v1", kind: "ClusterRole" },
+                        { apiVersion: "rbac.authorization.k8s.io/v1", kind: "ClusterRoleBinding" },
+                        { apiVersion: "rbac.authorization.k8s.io/v1", kind: "Role" },
+                        { apiVersion: "rbac.authorization.k8s.io/v1", kind: "RoleBinding" },
+                        { apiVersion: "storage.k8s.io/v1", kind: "StorageClass" },
+                    ],
+                },
+            ];
+            assert.deepStrictEqual(p, e);
+        });
+
+        it("should not populate kinds for exclude", () => {
+            const s: KubernetesResourceSelector[] = [{ action: "exclude", namespace: /^kube-/ }];
+            const p = populateResourceSelectorDefaults(s);
+            const e = [{ action: "exclude", namespace: /^kube-/ }];
+            assert.deepStrictEqual(p, e);
+        });
+
+        it("should keep the provided kinds", () => {
+            const s: KubernetesResourceSelector[] = [
+                { kinds: [{ apiVersion: "networking.k8s.io/v1", kind: "NetworkPolicy" }] },
+            ];
+            const p = populateResourceSelectorDefaults(s);
+            const e = [
+                {
+                    action: "include",
+                    kinds: [
+                        { apiVersion: "networking.k8s.io/v1", kind: "NetworkPolicy" },
+                    ],
+                },
+            ];
+            assert.deepStrictEqual(p, e);
+        });
+
+        it("should not add defaults if values already present", () => {
+            const s: KubernetesResourceSelector[] = [
+                {
+                    action: "exclude",
+                    kinds: [
+                        { apiVersion: "v1", kind: "Secret" },
+                        { apiVersion: "v1", kind: "Service" },
+                        { apiVersion: "apps/v1", kind: "Deployment" },
+                    ],
+                },
+            ];
+            const p = populateResourceSelectorDefaults(s);
+            const e = [
+                {
+                    action: "exclude",
+                    kinds: [
+                        { apiVersion: "v1", kind: "Secret" },
+                        { apiVersion: "v1", kind: "Service" },
+                        { apiVersion: "apps/v1", kind: "Deployment" },
+                    ],
+                },
+            ];
+            assert.deepStrictEqual(p, e);
+        });
+
+        it("should process multiple selectors", () => {
+            const s: KubernetesResourceSelector[] = [
+                {},
+                { kinds: [{ apiVersion: "networking.k8s.io/v1", kind: "NetworkPolicy" }] },
+                { action: "exclude", namespace: "kube-system" },
+                {
+                    action: "exclude",
+                    kinds: [
+                        { apiVersion: "v1", kind: "Secret" },
+                        { apiVersion: "v1", kind: "Service" },
+                        { apiVersion: "apps/v1", kind: "Deployment" },
+                    ],
+                },
+            ];
+            const p = populateResourceSelectorDefaults(s);
+            const e = [
+                {
+                    action: "include",
+                    kinds: [
+                        { apiVersion: "v1", kind: "ConfigMap" },
+                        { apiVersion: "v1", kind: "Secret" },
+                        { apiVersion: "v1", kind: "Service" },
+                        { apiVersion: "v1", kind: "ServiceAccount" },
+                        { apiVersion: "v1", kind: "PersistentVolume" },
+                        { apiVersion: "v1", kind: "PersistentVolumeClaim" },
+                        { apiVersion: "extensions/v1beta1", kind: "Ingress" },
+                        { apiVersion: "extensions/v1beta1", kind: "PodSecurityPolicy" },
+                        { apiVersion: "apps/v1", kind: "DaemonSet" },
+                        { apiVersion: "apps/v1", kind: "Deployment" },
+                        { apiVersion: "apps/v1", kind: "StatefulSet" },
+                        { apiVersion: "autoscaling/v1", kind: "HorizontalPodAutoscaler" },
+                        { apiVersion: "batch/v1beta1", kind: "CronJob" },
+                        { apiVersion: "networking.k8s.io/v1", kind: "NetworkPolicy" },
+                        { apiVersion: "policy/v1beta1", kind: "PodDisruptionBudget" },
+                        { apiVersion: "rbac.authorization.k8s.io/v1", kind: "ClusterRole" },
+                        { apiVersion: "rbac.authorization.k8s.io/v1", kind: "ClusterRoleBinding" },
+                        { apiVersion: "rbac.authorization.k8s.io/v1", kind: "Role" },
+                        { apiVersion: "rbac.authorization.k8s.io/v1", kind: "RoleBinding" },
+                        { apiVersion: "storage.k8s.io/v1", kind: "StorageClass" },
+                    ],
+                },
+                {
+                    action: "include",
+                    kinds: [{ apiVersion: "networking.k8s.io/v1", kind: "NetworkPolicy" }],
+                },
+                {
+                    action: "exclude",
+                    namespace: "kube-system",
+                },
+                {
+                    action: "exclude",
+                    kinds: [
+                        { apiVersion: "v1", kind: "Secret" },
+                        { apiVersion: "v1", kind: "Service" },
+                        { apiVersion: "apps/v1", kind: "Deployment" },
+                    ],
+                },
+            ];
+            assert.deepStrictEqual(p, e);
+        });
+
+        it("should remove empty exclusion selectors", () => {
+            const f = () => true;
+            const s: KubernetesResourceSelector[] = [
+                { action: "exclude" },
+                { kinds: [{ apiVersion: "networking.k8s.io/v1", kind: "NetworkPolicy" }] },
+                { action: "exclude", namespace: "kube-system" },
+                { action: "exclude" },
+                {
+                    action: "exclude",
+                    kinds: [
+                        { apiVersion: "v1", kind: "Secret" },
+                        { apiVersion: "v1", kind: "Service" },
+                        { apiVersion: "apps/v1", kind: "Deployment" },
+                    ],
+                },
+                { action: "exclude", filter: f },
+                { action: "exclude" },
+            ];
+            const p = populateResourceSelectorDefaults(s);
+            const e = [
+                {
+                    action: "include",
+                    kinds: [{ apiVersion: "networking.k8s.io/v1", kind: "NetworkPolicy" }],
+                },
+                {
+                    action: "exclude",
+                    namespace: "kube-system",
+                },
+                {
+                    action: "exclude",
+                    kinds: [
+                        { apiVersion: "v1", kind: "Secret" },
+                        { apiVersion: "v1", kind: "Service" },
+                        { apiVersion: "apps/v1", kind: "Deployment" },
+                    ],
+                },
+                { action: "exclude", filter: f },
+            ];
+            assert.deepStrictEqual(p, e);
+        });
+
+    });
+
+    describe("clusterResourcesKinds", () => {
+
+        it("should return empty array if no cluster resources", () => {
+            const s: KubernetesResourceSelector[] = [
+                {
+                    action: "include",
+                    kinds: [
+                        { apiVersion: "v1", kind: "ConfigMap" },
+                        { apiVersion: "v1", kind: "Secret" },
+                        { apiVersion: "v1", kind: "Service" },
+                        { apiVersion: "v1", kind: "ServiceAccount" },
+                    ],
+                },
+                {
+                    action: "include",
+                    kinds: [
+                        { apiVersion: "v1", kind: "PersistentVolumeClaim" },
+                        { apiVersion: "extensions/v1beta1", kind: "Ingress" },
+                        { apiVersion: "apps/v1", kind: "DaemonSet" },
+                        { apiVersion: "apps/v1", kind: "Deployment" },
+                        { apiVersion: "apps/v1", kind: "StatefulSet" },
+                    ],
+                },
+                {
+                    action: "include",
+                    kinds: [
+                        { apiVersion: "autoscaling/v1", kind: "HorizontalPodAutoscaler" },
+                        { apiVersion: "batch/v1beta1", kind: "CronJob" },
+                        { apiVersion: "networking.k8s.io/v1", kind: "NetworkPolicy" },
+                        { apiVersion: "rbac.authorization.k8s.io/v1", kind: "Role" },
+                        { apiVersion: "rbac.authorization.k8s.io/v1", kind: "RoleBinding" },
+                    ],
+                },
+                {
+                    action: "include",
+                    kinds: [
+                        { apiVersion: "v1", kind: "Service" },
+                        { apiVersion: "v1", kind: "ServiceAccount" },
+                    ],
+                },
+            ];
+            const c = clusterResourceKinds(s);
+            assert.deepStrictEqual(c, []);
+        });
+
+        it("should return cluster resources from default", () => {
+            const s: KubernetesResourceSelector[] = [{ action: "include", kinds: defaultKubernetesResourceSelectorKinds }];
+            const c = clusterResourceKinds(s);
+            const e = [
+                { apiVersion: "v1", kind: "PersistentVolume" },
+                { apiVersion: "extensions/v1beta1", kind: "PodSecurityPolicy" },
+                { apiVersion: "rbac.authorization.k8s.io/v1", kind: "ClusterRole" },
+                { apiVersion: "rbac.authorization.k8s.io/v1", kind: "ClusterRoleBinding" },
+                { apiVersion: "storage.k8s.io/v1", kind: "StorageClass" },
+            ];
+            assert.deepStrictEqual(c, e);
+        });
+
+        it("should deduplicate cluster resources", () => {
+            const s: KubernetesResourceSelector[] = [
+                { action: "include", kinds: defaultKubernetesResourceSelectorKinds },
+                { action: "include", kinds: defaultKubernetesResourceSelectorKinds },
+                { action: "include", kinds: defaultKubernetesResourceSelectorKinds },
+            ];
+            const c = clusterResourceKinds(s);
+            const e = [
+                { apiVersion: "v1", kind: "PersistentVolume" },
+                { apiVersion: "extensions/v1beta1", kind: "PodSecurityPolicy" },
+                { apiVersion: "rbac.authorization.k8s.io/v1", kind: "ClusterRole" },
+                { apiVersion: "rbac.authorization.k8s.io/v1", kind: "ClusterRoleBinding" },
+                { apiVersion: "storage.k8s.io/v1", kind: "StorageClass" },
+            ];
+            assert.deepStrictEqual(c, e);
+        });
+
+        it("should return nothing from exclude", () => {
+            const s: KubernetesResourceSelector[] = [{ action: "exclude", kinds: defaultKubernetesResourceSelectorKinds }];
+            const c = clusterResourceKinds(s);
+            assert.deepStrictEqual(c, []);
+        });
+
+    });
+
+    describe("includedResourceKinds", () => {
+
+        it("should find nothing successfully", () => {
+            const s = includedResourceKinds([]);
+            assert.deepStrictEqual(s, []);
+        });
+
+        it("should return included resource kinds", () => {
+            const s: KubernetesResourceSelector[] = [
+                {
+                    action: "include",
+                    kinds: [
+                        { apiVersion: "v1", kind: "ConfigMap" },
+                        { apiVersion: "v1", kind: "Secret" },
+                        { apiVersion: "v1", kind: "Service" },
+                        { apiVersion: "v1", kind: "ServiceAccount" },
+                    ],
+                },
+                {
+                    action: "include",
+                    kinds: [
+                        { apiVersion: "v1", kind: "PersistentVolumeClaim" },
+                        { apiVersion: "extensions/v1beta1", kind: "Ingress" },
+                        { apiVersion: "apps/v1", kind: "DaemonSet" },
+                        { apiVersion: "apps/v1", kind: "Deployment" },
+                        { apiVersion: "apps/v1", kind: "StatefulSet" },
+                    ],
+                },
+                {
+                    action: "include",
+                    kinds: [
+                        { apiVersion: "autoscaling/v1", kind: "HorizontalPodAutoscaler" },
+                        { apiVersion: "batch/v1beta1", kind: "CronJob" },
+                        { apiVersion: "networking.k8s.io/v1", kind: "NetworkPolicy" },
+                        { apiVersion: "rbac.authorization.k8s.io/v1", kind: "Role" },
+                        { apiVersion: "rbac.authorization.k8s.io/v1", kind: "RoleBinding" },
+                    ],
+                },
+            ];
+            const c = includedResourceKinds(s);
+            const e = [
+                { apiVersion: "v1", kind: "ConfigMap" },
+                { apiVersion: "v1", kind: "Secret" },
+                { apiVersion: "v1", kind: "Service" },
+                { apiVersion: "v1", kind: "ServiceAccount" },
+                { apiVersion: "v1", kind: "PersistentVolumeClaim" },
+                { apiVersion: "extensions/v1beta1", kind: "Ingress" },
+                { apiVersion: "apps/v1", kind: "DaemonSet" },
+                { apiVersion: "apps/v1", kind: "Deployment" },
+                { apiVersion: "apps/v1", kind: "StatefulSet" },
+                { apiVersion: "autoscaling/v1", kind: "HorizontalPodAutoscaler" },
+                { apiVersion: "batch/v1beta1", kind: "CronJob" },
+                { apiVersion: "networking.k8s.io/v1", kind: "NetworkPolicy" },
+                { apiVersion: "rbac.authorization.k8s.io/v1", kind: "Role" },
+                { apiVersion: "rbac.authorization.k8s.io/v1", kind: "RoleBinding" },
+            ];
+            assert.deepStrictEqual(c, e);
+        });
+
+        it("should return included resource kinds and dedupe", () => {
+            const s: KubernetesResourceSelector[] = [
+                {
+                    action: "include",
+                    kinds: [
+                        { apiVersion: "v1", kind: "ConfigMap" },
+                        { apiVersion: "v1", kind: "Secret" },
+                        { apiVersion: "v1", kind: "Service" },
+                        { apiVersion: "v1", kind: "ServiceAccount" },
+                    ],
+                },
+                {
+                    action: "include",
+                    kinds: [
+                        { apiVersion: "v1", kind: "PersistentVolumeClaim" },
+                        { apiVersion: "extensions/v1beta1", kind: "Ingress" },
+                        { apiVersion: "apps/v1", kind: "DaemonSet" },
+                        { apiVersion: "apps/v1", kind: "Deployment" },
+                        { apiVersion: "apps/v1", kind: "StatefulSet" },
+                    ],
+                },
+                {
+                    action: "include",
+                    kinds: [
+                        { apiVersion: "autoscaling/v1", kind: "HorizontalPodAutoscaler" },
+                        { apiVersion: "batch/v1beta1", kind: "CronJob" },
+                        { apiVersion: "networking.k8s.io/v1", kind: "NetworkPolicy" },
+                        { apiVersion: "rbac.authorization.k8s.io/v1", kind: "Role" },
+                        { apiVersion: "rbac.authorization.k8s.io/v1", kind: "RoleBinding" },
+                    ],
+                },
+                {
+                    action: "include",
+                    kinds: [
+                        { apiVersion: "v1", kind: "Service" },
+                        { apiVersion: "v1", kind: "ServiceAccount" },
+                    ],
+                },
+            ];
+            const c = includedResourceKinds(s);
+            const e = [
+                { apiVersion: "v1", kind: "ConfigMap" },
+                { apiVersion: "v1", kind: "Secret" },
+                { apiVersion: "v1", kind: "Service" },
+                { apiVersion: "v1", kind: "ServiceAccount" },
+                { apiVersion: "v1", kind: "PersistentVolumeClaim" },
+                { apiVersion: "extensions/v1beta1", kind: "Ingress" },
+                { apiVersion: "apps/v1", kind: "DaemonSet" },
+                { apiVersion: "apps/v1", kind: "Deployment" },
+                { apiVersion: "apps/v1", kind: "StatefulSet" },
+                { apiVersion: "autoscaling/v1", kind: "HorizontalPodAutoscaler" },
+                { apiVersion: "batch/v1beta1", kind: "CronJob" },
+                { apiVersion: "networking.k8s.io/v1", kind: "NetworkPolicy" },
+                { apiVersion: "rbac.authorization.k8s.io/v1", kind: "Role" },
+                { apiVersion: "rbac.authorization.k8s.io/v1", kind: "RoleBinding" },
+            ];
+            assert.deepStrictEqual(c, e);
+        });
+
+        it("should not include excluded resource kinds", () => {
+            const s: KubernetesResourceSelector[] = [
+                {
+                    action: "exclude",
+                    kinds: [
+                        { apiVersion: "v1", kind: "ConfigMap" },
+                        { apiVersion: "v1", kind: "Secret" },
+                        { apiVersion: "v1", kind: "Service" },
+                        { apiVersion: "v1", kind: "ServiceAccount" },
+                    ],
+                },
+                {
+                    action: "exclude",
+                    kinds: [
+                        { apiVersion: "v1", kind: "PersistentVolumeClaim" },
+                        { apiVersion: "extensions/v1beta1", kind: "Ingress" },
+                        { apiVersion: "apps/v1", kind: "DaemonSet" },
+                        { apiVersion: "apps/v1", kind: "Deployment" },
+                        { apiVersion: "apps/v1", kind: "StatefulSet" },
+                    ],
+                },
+                {
+                    action: "exclude",
+                    kinds: [
+                        { apiVersion: "autoscaling/v1", kind: "HorizontalPodAutoscaler" },
+                        { apiVersion: "batch/v1beta1", kind: "CronJob" },
+                        { apiVersion: "networking.k8s.io/v1", kind: "NetworkPolicy" },
+                        { apiVersion: "rbac.authorization.k8s.io/v1", kind: "Role" },
+                        { apiVersion: "rbac.authorization.k8s.io/v1", kind: "RoleBinding" },
+                    ],
+                },
+            ];
+            const c = includedResourceKinds(s);
+            assert.deepStrictEqual(c, []);
+        });
+
+        it("should return only included resource kinds and dedupe", () => {
+            const s: KubernetesResourceSelector[] = [
+                {
+                    action: "include",
+                    kinds: [
+                        { apiVersion: "v1", kind: "ConfigMap" },
+                        { apiVersion: "v1", kind: "Secret" },
+                        { apiVersion: "v1", kind: "Service" },
+                        { apiVersion: "v1", kind: "ServiceAccount" },
+                    ],
+                },
+                {
+                    action: "exclude",
+                    kinds: [
+                        { apiVersion: "v1", kind: "PersistentVolumeClaim" },
+                        { apiVersion: "extensions/v1beta1", kind: "Ingress" },
+                        { apiVersion: "apps/v1", kind: "DaemonSet" },
+                        { apiVersion: "apps/v1", kind: "Deployment" },
+                        { apiVersion: "apps/v1", kind: "StatefulSet" },
+                    ],
+                },
+                {
+                    action: "include",
+                    kinds: [
+                        { apiVersion: "v1", kind: "PersistentVolume" },
+                        { apiVersion: "extensions/v1beta1", kind: "PodSecurityPolicy" },
+                        { apiVersion: "rbac.authorization.k8s.io/v1", kind: "ClusterRole" },
+                        { apiVersion: "rbac.authorization.k8s.io/v1", kind: "ClusterRoleBinding" },
+                        { apiVersion: "storage.k8s.io/v1", kind: "StorageClass" },
+                    ],
+                },
+                {
+                    action: "include",
+                    kinds: [
+                        { apiVersion: "autoscaling/v1", kind: "HorizontalPodAutoscaler" },
+                        { apiVersion: "batch/v1beta1", kind: "CronJob" },
+                        { apiVersion: "networking.k8s.io/v1", kind: "NetworkPolicy" },
+                        { apiVersion: "rbac.authorization.k8s.io/v1", kind: "Role" },
+                        { apiVersion: "rbac.authorization.k8s.io/v1", kind: "RoleBinding" },
+                    ],
+                },
+                {
+                    action: "exclude",
+                    kinds: [
+                        { apiVersion: "v1", kind: "PersistentVolume" },
+                        { apiVersion: "extensions/v1beta1", kind: "PodSecurityPolicy" },
+                        { apiVersion: "rbac.authorization.k8s.io/v1", kind: "ClusterRole" },
+                    ],
+                },
+                {
+                    action: "include",
+                    kinds: [
+                        { apiVersion: "v1", kind: "Service" },
+                        { apiVersion: "v1", kind: "ServiceAccount" },
+                    ],
+                },
+                {
+                    action: "include",
+                    kinds: [
+                        { apiVersion: "rbac.authorization.k8s.io/v1", kind: "ClusterRole" },
+                        { apiVersion: "rbac.authorization.k8s.io/v1", kind: "ClusterRoleBinding" },
+                        { apiVersion: "storage.k8s.io/v1", kind: "StorageClass" },
+                    ],
+                },
+            ];
+            const c = includedResourceKinds(s);
+            const e = [
+                { apiVersion: "v1", kind: "ConfigMap" },
+                { apiVersion: "v1", kind: "Secret" },
+                { apiVersion: "v1", kind: "Service" },
+                { apiVersion: "v1", kind: "ServiceAccount" },
+                { apiVersion: "v1", kind: "PersistentVolume" },
+                { apiVersion: "extensions/v1beta1", kind: "PodSecurityPolicy" },
+                { apiVersion: "rbac.authorization.k8s.io/v1", kind: "ClusterRole" },
+                { apiVersion: "rbac.authorization.k8s.io/v1", kind: "ClusterRoleBinding" },
+                { apiVersion: "storage.k8s.io/v1", kind: "StorageClass" },
+                { apiVersion: "autoscaling/v1", kind: "HorizontalPodAutoscaler" },
+                { apiVersion: "batch/v1beta1", kind: "CronJob" },
+                { apiVersion: "networking.k8s.io/v1", kind: "NetworkPolicy" },
+                { apiVersion: "rbac.authorization.k8s.io/v1", kind: "Role" },
+                { apiVersion: "rbac.authorization.k8s.io/v1", kind: "RoleBinding" },
+            ];
+            assert.deepStrictEqual(c, e);
+        });
+
+    });
+
+    describe("namespaceResourceKinds", () => {
+
+        it("should find nothing successfully", () => {
+            const n = "son-house";
+            const s = namespaceResourceKinds(n, []);
+            assert.deepStrictEqual(s, []);
+        });
+
+        it("should return include resource kinds with no namespace selector", () => {
+            const n = "son-house";
+            const s: KubernetesResourceSelector[] = [
+                {
+                    action: "include",
+                    kinds: [
+                        { apiVersion: "v1", kind: "ConfigMap" },
+                        { apiVersion: "v1", kind: "Secret" },
+                        { apiVersion: "v1", kind: "Service" },
+                        { apiVersion: "v1", kind: "ServiceAccount" },
+                    ],
+                },
+            ];
+            const c = namespaceResourceKinds(n, s);
+            const e = [
+                { apiVersion: "v1", kind: "ConfigMap" },
+                { apiVersion: "v1", kind: "Secret" },
+                { apiVersion: "v1", kind: "Service" },
+                { apiVersion: "v1", kind: "ServiceAccount" },
+            ];
+            assert.deepStrictEqual(c, e);
+        });
+
+        it("should return include resource kinds with string namespace selector", () => {
+            const n = "son-house";
+            const s: KubernetesResourceSelector[] = [
+                {
+                    action: "include",
+                    kinds: [
+                        { apiVersion: "v1", kind: "ConfigMap" },
+                        { apiVersion: "v1", kind: "Secret" },
+                        { apiVersion: "v1", kind: "Service" },
+                        { apiVersion: "v1", kind: "ServiceAccount" },
+                    ],
+                    namespace: "son-house",
+                },
+            ];
+            const c = namespaceResourceKinds(n, s);
+            const e = [
+                { apiVersion: "v1", kind: "ConfigMap" },
+                { apiVersion: "v1", kind: "Secret" },
+                { apiVersion: "v1", kind: "Service" },
+                { apiVersion: "v1", kind: "ServiceAccount" },
+            ];
+            assert.deepStrictEqual(c, e);
+        });
+
+        it("should return include resource kinds with regular expression namespace selector", () => {
+            const n = "son-house";
+            const s: KubernetesResourceSelector[] = [
+                {
+                    action: "include",
+                    kinds: [
+                        { apiVersion: "v1", kind: "ConfigMap" },
+                        { apiVersion: "v1", kind: "Secret" },
+                        { apiVersion: "v1", kind: "Service" },
+                        { apiVersion: "v1", kind: "ServiceAccount" },
+                    ],
+                    namespace: /on-hous/,
+                },
+            ];
+            const c = namespaceResourceKinds(n, s);
+            const e = [
+                { apiVersion: "v1", kind: "ConfigMap" },
+                { apiVersion: "v1", kind: "Secret" },
+                { apiVersion: "v1", kind: "Service" },
+                { apiVersion: "v1", kind: "ServiceAccount" },
+            ];
+            assert.deepStrictEqual(c, e);
+        });
+
+        it("should return nothing from exclude selectors", () => {
+            const n = "son-house";
+            const s: KubernetesResourceSelector[] = [
+                {
+                    action: "exclude",
+                    kinds: [
+                        { apiVersion: "v1", kind: "ConfigMap" },
+                        { apiVersion: "v1", kind: "Secret" },
+                        { apiVersion: "v1", kind: "Service" },
+                        { apiVersion: "v1", kind: "ServiceAccount" },
+                    ],
+                },
+            ];
+            const c = namespaceResourceKinds(n, s);
+            assert.deepStrictEqual(c, []);
+        });
+
+        it("should return included resource kinds and dedupe", () => {
+            const n = "son-house";
+            const s: KubernetesResourceSelector[] = [
+                {
+                    action: "include",
+                    kinds: [
+                        { apiVersion: "v1", kind: "ConfigMap" },
+                        { apiVersion: "v1", kind: "Secret" },
+                        { apiVersion: "v1", kind: "Service" },
+                        { apiVersion: "v1", kind: "ServiceAccount" },
+                    ],
+                },
+                {
+                    action: "include",
+                    kinds: [
+                        { apiVersion: "v1", kind: "PersistentVolumeClaim" },
+                        { apiVersion: "extensions/v1beta1", kind: "Ingress" },
+                        { apiVersion: "apps/v1", kind: "DaemonSet" },
+                        { apiVersion: "apps/v1", kind: "Deployment" },
+                        { apiVersion: "apps/v1", kind: "StatefulSet" },
+                    ],
+                    namespace: "son-house",
+                },
+                {
+                    action: "include",
+                    kinds: [
+                        { apiVersion: "autoscaling/v1", kind: "HorizontalPodAutoscaler" },
+                        { apiVersion: "batch/v1beta1", kind: "CronJob" },
+                        { apiVersion: "networking.k8s.io/v1", kind: "NetworkPolicy" },
+                        { apiVersion: "rbac.authorization.k8s.io/v1", kind: "Role" },
+                        { apiVersion: "rbac.authorization.k8s.io/v1", kind: "RoleBinding" },
+                    ],
+                    namespace: /houses?$/,
+                },
+                {
+                    action: "include",
+                    kinds: [
+                        { apiVersion: "v1", kind: "Service" },
+                        { apiVersion: "v1", kind: "ServiceAccount" },
+                        { apiVersion: "rbac.authorization.k8s.io/v1", kind: "RoleBinding" },
+                    ],
+                },
+            ];
+            const c = namespaceResourceKinds(n, s);
+            const e = [
+                { apiVersion: "v1", kind: "ConfigMap" },
+                { apiVersion: "v1", kind: "Secret" },
+                { apiVersion: "v1", kind: "Service" },
+                { apiVersion: "v1", kind: "ServiceAccount" },
+                { apiVersion: "v1", kind: "PersistentVolumeClaim" },
+                { apiVersion: "extensions/v1beta1", kind: "Ingress" },
+                { apiVersion: "apps/v1", kind: "DaemonSet" },
+                { apiVersion: "apps/v1", kind: "Deployment" },
+                { apiVersion: "apps/v1", kind: "StatefulSet" },
+                { apiVersion: "autoscaling/v1", kind: "HorizontalPodAutoscaler" },
+                { apiVersion: "batch/v1beta1", kind: "CronJob" },
+                { apiVersion: "networking.k8s.io/v1", kind: "NetworkPolicy" },
+                { apiVersion: "rbac.authorization.k8s.io/v1", kind: "Role" },
+                { apiVersion: "rbac.authorization.k8s.io/v1", kind: "RoleBinding" },
+            ];
+            assert.deepStrictEqual(c, e);
+        });
+
+        it("should include included that are also excluded", () => {
+            const n = "son-house";
+            const s: KubernetesResourceSelector[] = [
+                {
+                    action: "exclude",
+                    kinds: [
+                        { apiVersion: "v1", kind: "ConfigMap" },
+                        { apiVersion: "v1", kind: "Secret" },
+                        { apiVersion: "v1", kind: "Service" },
+                        { apiVersion: "v1", kind: "ServiceAccount" },
+                    ],
+                },
+                {
+                    action: "include",
+                    kinds: [
+                        { apiVersion: "v1", kind: "ConfigMap" },
+                        { apiVersion: "v1", kind: "Secret" },
+                        { apiVersion: "v1", kind: "Service" },
+                        { apiVersion: "v1", kind: "ServiceAccount" },
+                    ],
+                    namespace: /(house|home)/,
+                },
+                {
+                    action: "exclude",
+                    kinds: [
+                        { apiVersion: "v1", kind: "Secret" },
+                        { apiVersion: "v1", kind: "ConfigMap" },
+                        { apiVersion: "v1", kind: "Secret" },
+                        { apiVersion: "v1", kind: "ServiceAccount" },
+                    ],
+                    namespace: "son-house",
+                },
+            ];
+            const c = namespaceResourceKinds(n, s);
+            const e = [
+                { apiVersion: "v1", kind: "ConfigMap" },
+                { apiVersion: "v1", kind: "Secret" },
+                { apiVersion: "v1", kind: "Service" },
+                { apiVersion: "v1", kind: "ServiceAccount" },
+            ];
+            assert.deepStrictEqual(c, e);
+        });
+
+        it("should not return cluster resources", () => {
+            const n = "son-house";
+            const s: KubernetesResourceSelector[] = [
+                {
+                    action: "include",
+                    kinds: [
+                        { apiVersion: "v1", kind: "PersistentVolume" },
+                        { apiVersion: "extensions/v1beta1", kind: "PodSecurityPolicy" },
+                        { apiVersion: "rbac.authorization.k8s.io/v1", kind: "ClusterRole" },
+                        { apiVersion: "rbac.authorization.k8s.io/v1", kind: "ClusterRoleBinding" },
+                        { apiVersion: "storage.k8s.io/v1", kind: "StorageClass" },
+                    ],
+                },
+            ];
+            const c = namespaceResourceKinds(n, s);
+            assert.deepStrictEqual(c, []);
+        });
+
+    });
+
+    describe("cleanKubernetesSpec", () => {
+
+        it("should do nothing safely", () => {
+            const c = cleanKubernetesSpec(undefined, { apiVersion: "v1", kind: "Secret" });
+            assert(c === undefined);
+        });
+
+        it("should populate the apiVersion and kind", () => {
+            const c = cleanKubernetesSpec({}, { apiVersion: "v1", kind: "Secret" });
+            const e = { apiVersion: "v1", kind: "Secret" };
+            assert.deepStrictEqual(c, e);
+        });
+
+        it("should not overwrite the apiVersion and kind", () => {
+            const s = { apiVersion: "apps/v1", kind: "Deployment" };
+            const c = cleanKubernetesSpec(s, { apiVersion: "v1", kind: "Secret" });
+            const e = { apiVersion: "apps/v1", kind: "Deployment" };
+            assert.deepStrictEqual(c, e);
+        });
+
+        it("should remove unneeded properties", () => {
+            const s: any = {
+                apiVersion: "extensions/v1beta1",
+                kind: "Deployment",
+                metadata: {
+                    annotations: {
+                        "atomist.sha": "ee71cfb6eb63ee0ddc8875cb211074277b543d76",
+                        "deployment.kubernetes.io/revision": "2008",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{}",
+                    },
+                    creationTimestamp: "2008-09-16T09:52:09Z",
+                    generation: 13,
+                    labels: {
+                        "app.kubernetes.io/managed-by": "columbia",
+                        "app.kubernetes.io/name": "the-way-i-see-it",
+                        "app.kubernetes.io/part-of": "the-way-i-see-it",
+                        "atomist.com/workspaceId": "APHA31",
+                    },
+                    name: "the-way-i-see-it",
+                    namespace: "raphael-saadiq",
+                    resourceVersion: "4207",
+                    selfLink: "/apis/extensions/v1beta1/namespaces/raphael-saadiq/deployments/the-way-i-see-it",
+                    uid: "31c06e3f-303e-11e9-b6a6-42010af001a7",
+                },
+                spec: {
+                    progressDeadlineSeconds: 2147483647,
+                    replicas: 2,
+                    revisionHistoryLimit: 3,
+                    selector: {
+                        matchLabels: {
+                            "app.kubernetes.io/name": "the-way-i-see-it",
+                            "atomist.com/workspaceId": "APHA31",
+                        },
+                    },
+                    strategy: {
+                        rollingUpdate: {
+                            maxSurge: 1,
+                            maxUnavailable: 0,
+                        },
+                        type: "RollingUpdate",
+                    },
+                    template: {
+                        metadata: {
+                            creationTimestamp: undefined,
+                            labels: {
+                                "app.kubernetes.io/managed-by": "columbia",
+                                "app.kubernetes.io/name": "the-way-i-see-it",
+                                "app.kubernetes.io/part-of": "the-way-i-see-it",
+                                "atomist.com/workspaceId": "APHA31",
+                            },
+                        },
+                        spec: {
+                            containers: [{
+                                image: "raphaelsaadiq/the-way-i-see-it:2008",
+                                name: "the-way-i-see-it",
+                            }],
+                        },
+                    },
+                },
+                status: {
+                    availableReplicas: 2,
+                    conditions: [
+                        {
+                            lastTransitionTime: "2019-06-28T21:02:49Z",
+                            lastUpdateTime: "2019-06-28T21:02:49Z",
+                            message: "Deployment has minimum availability.",
+                            reason: "MinimumReplicasAvailable",
+                            status: "True",
+                            type: "Available",
+                        },
+                    ],
+                    observedGeneration: 13,
+                    readyReplicas: 2,
+                    replicas: 2,
+                    updatedReplicas: 2,
+                },
+            };
+            const c = cleanKubernetesSpec(s, { apiVersion: "apps/v1", kind: "Deployment" });
+            const e = {
+                apiVersion: "extensions/v1beta1",
+                kind: "Deployment",
+                metadata: {
+                    annotations: {
+                        "atomist.sha": "ee71cfb6eb63ee0ddc8875cb211074277b543d76",
+                    },
+                    labels: {
+                        "app.kubernetes.io/managed-by": "columbia",
+                        "app.kubernetes.io/name": "the-way-i-see-it",
+                        "app.kubernetes.io/part-of": "the-way-i-see-it",
+                        "atomist.com/workspaceId": "APHA31",
+                    },
+                    name: "the-way-i-see-it",
+                    namespace: "raphael-saadiq",
+                },
+                spec: {
+                    progressDeadlineSeconds: 2147483647,
+                    replicas: 2,
+                    revisionHistoryLimit: 3,
+                    selector: {
+                        matchLabels: {
+                            "app.kubernetes.io/name": "the-way-i-see-it",
+                            "atomist.com/workspaceId": "APHA31",
+                        },
+                    },
+                    strategy: {
+                        rollingUpdate: {
+                            maxSurge: 1,
+                            maxUnavailable: 0,
+                        },
+                        type: "RollingUpdate",
+                    },
+                    template: {
+                        metadata: {
+                            labels: {
+                                "app.kubernetes.io/managed-by": "columbia",
+                                "app.kubernetes.io/name": "the-way-i-see-it",
+                                "app.kubernetes.io/part-of": "the-way-i-see-it",
+                                "atomist.com/workspaceId": "APHA31",
+                            },
+                        },
+                        spec: {
+                            containers: [{
+                                image: "raphaelsaadiq/the-way-i-see-it:2008",
+                                name: "the-way-i-see-it",
+                            }],
+                        },
+                    },
+                },
+            };
+            assert.deepStrictEqual(c, e);
+        });
+
+        it("should remove empty annotations", () => {
+            const s: any = {
+                metadata: {
+                    annotations: {
+                        "deployment.kubernetes.io/revision": "2008",
+                        "kubectl.kubernetes.io/last-applied-configuration": "{}",
+                    },
+                    name: "the-way-i-see-it",
+                    namespace: "raphael-saadiq",
+                },
+            };
+            const c = cleanKubernetesSpec(s, { apiVersion: "v1", kind: "Secret" });
+            const e = {
+                apiVersion: "v1",
+                kind: "Secret",
+                metadata: {
+                    name: "the-way-i-see-it",
+                    namespace: "raphael-saadiq",
+                },
+            };
+            assert.deepStrictEqual(c, e);
+        });
+
+    });
+
+    describe("kubernetesResourceIdentity", () => {
+
+        it("should return all unique objects", () => {
+            const o = [
+                { apiVersion: "v1", kind: "Secret", metadata: { name: "you-really-got-me", namespace: "kinks" } },
+                { kind: "Deployment", metadata: { name: "waterloo-sunset", namespace: "something-else" } },
+                { kind: "Deployment", metadata: { name: "waterloo-sunset-mono", namespace: "something-else" } },
+                { kind: "DaemonSet", metadata: { name: "sunny-afternoon", namespace: "face2face" } },
+                { kind: "DaemonSet", metadata: { name: "sunny-afternoon", namespace: "face-to-face" } },
+                { kind: "Service", metadata: { name: "tired-of-waiting-for-you", namespace: "kinda-kinks" } },
+                { kind: "ServiceAccount", metadata: { name: "tired-of-waiting-for-you", namespace: "kinda-kinks" } },
+                { kind: "ClusterRole", metadata: { name: "the-kinks-are-the-village-green-preservation-society" } },
+            ];
+            const u = _.uniqBy(o, kubernetesResourceIdentity);
+            const e = [
+                { apiVersion: "v1", kind: "Secret", metadata: { name: "you-really-got-me", namespace: "kinks" } },
+                { kind: "Deployment", metadata: { name: "waterloo-sunset", namespace: "something-else" } },
+                { kind: "Deployment", metadata: { name: "waterloo-sunset-mono", namespace: "something-else" } },
+                { kind: "DaemonSet", metadata: { name: "sunny-afternoon", namespace: "face2face" } },
+                { kind: "DaemonSet", metadata: { name: "sunny-afternoon", namespace: "face-to-face" } },
+                { kind: "Service", metadata: { name: "tired-of-waiting-for-you", namespace: "kinda-kinks" } },
+                { kind: "ServiceAccount", metadata: { name: "tired-of-waiting-for-you", namespace: "kinda-kinks" } },
+                { kind: "ClusterRole", metadata: { name: "the-kinks-are-the-village-green-preservation-society" } },
+            ];
+            assert.deepStrictEqual(u, e);
+        });
+
+        it("should filter out duplicates", () => {
+            const o = [
+                { kind: "Secret", metadata: { name: "you-really-got-me", namespace: "kinks" } },
+                { apiVersion: "apps/v1", kind: "Deployment", metadata: { name: "waterloo-sunset", namespace: "something-else" } },
+                { apiVersion: "extensions/v1beta1", kind: "Deployment", metadata: { name: "waterloo-sunset", namespace: "something-else" } },
+                { apiVersion: "extensions/v1beta1", kind: "DaemonSet", metadata: { name: "sunny-afternoon", namespace: "face2face" } },
+                { apiVersion: "apps/v1", kind: "DaemonSet", metadata: { name: "sunny-afternoon", namespace: "face2face" } },
+                { kind: "Service", metadata: { name: "tired-of-waiting-for-you", namespace: "kinda-kinks" } },
+                { kind: "ServiceAccount", metadata: { name: "tired-of-waiting-for-you", namespace: "kinda-kinks" } },
+                { kind: "ClusterRole", metadata: { name: "the-kinks-are-the-village-green-preservation-society" } },
+            ];
+            const u = _.uniqBy(o, kubernetesResourceIdentity);
+            const e = [
+                { kind: "Secret", metadata: { name: "you-really-got-me", namespace: "kinks" } },
+                { apiVersion: "apps/v1", kind: "Deployment", metadata: { name: "waterloo-sunset", namespace: "something-else" } },
+                { apiVersion: "extensions/v1beta1", kind: "DaemonSet", metadata: { name: "sunny-afternoon", namespace: "face2face" } },
+                { kind: "Service", metadata: { name: "tired-of-waiting-for-you", namespace: "kinda-kinks" } },
+                { kind: "ServiceAccount", metadata: { name: "tired-of-waiting-for-you", namespace: "kinda-kinks" } },
+                { kind: "ClusterRole", metadata: { name: "the-kinks-are-the-village-green-preservation-society" } },
+            ];
+            assert.deepStrictEqual(u, e);
+        });
+
+    });
+
+    describe("selectKubernetesResources", () => {
+
+        it("should do nothing successfully", () => {
+            const r: K8sObject[] = [];
+            const s: KubernetesResourceSelector[] = [];
+            const o = selectKubernetesResources(r, s);
+            assert.deepStrictEqual(o, []);
+        });
+
+        it("should return everything if no selectors", () => {
+            const r: K8sObject[] = [
+                { apiVersion: "v1", kind: "Secret", metadata: { name: "you-really-got-me", namespace: "kinks" } },
+                { kind: "Deployment", metadata: { name: "waterloo-sunset", namespace: "something-else" } },
+                { kind: "DaemonSet", metadata: { name: "sunny-afternoon", namespace: "face2face" } },
+                { kind: "Service", metadata: { name: "tired-of-waiting-for-you", namespace: "kinda-kinks" } },
+                { kind: "ServiceAccount", metadata: { name: "tired-of-waiting-for-you", namespace: "kinda-kinks" } },
+                { kind: "ClusterRole", metadata: { name: "the-kinks-are-the-village-green-preservation-society" } },
+            ];
+            const e = [
+                { apiVersion: "v1", kind: "Secret", metadata: { name: "you-really-got-me", namespace: "kinks" } },
+                { kind: "Deployment", metadata: { name: "waterloo-sunset", namespace: "something-else" } },
+                { kind: "DaemonSet", metadata: { name: "sunny-afternoon", namespace: "face2face" } },
+                { kind: "Service", metadata: { name: "tired-of-waiting-for-you", namespace: "kinda-kinks" } },
+                { kind: "ServiceAccount", metadata: { name: "tired-of-waiting-for-you", namespace: "kinda-kinks" } },
+                { kind: "ClusterRole", metadata: { name: "the-kinks-are-the-village-green-preservation-society" } },
+            ];
+            [[], undefined].forEach(s => {
+                const o = selectKubernetesResources(r, s);
+                assert.deepStrictEqual(o, e);
+            });
+        });
+
+        it("should filter resources using defaults", () => {
+            const r: any[] = [
+                { apiVersion: "v1", kind: "Secret", metadata: { name: "you-really-got-me", namespace: "kinks" } },
+                { kind: "ClusterRole", metadata: { name: "admin" } },
+                { kind: "ClusterRole", metadata: { name: "cluster-admin" } },
+                { kind: "ClusterRole", metadata: { name: "edit" } },
+                { kind: "ClusterRole", metadata: { name: "view" } },
+                { kind: "ClusterRole", metadata: { name: "cloud-provider" } },
+                { kind: "ClusterRole", metadata: { name: "kubelet-api-admin" } },
+                { kind: "Deployment", metadata: { name: "waterloo-sunset", namespace: "something-else" } },
+                { kind: "Deployment", metadata: { name: "waterloo-sunset-mono", namespace: "something-else" } },
+                { kind: "ClusterRoleBinding", metadata: { name: "cluster-admin" } },
+                { kind: "ClusterRoleBinding", metadata: { name: "cluster-admin-binding" } },
+                { kind: "ClusterRoleBinding", metadata: { name: "kube-apiserver-kubelet-api-admin" } },
+                { kind: "ClusterRoleBinding", metadata: { name: "cloud-provider" } },
+                { kind: "ClusterRoleBinding", metadata: { name: "microsoft:writer" } },
+                { kind: "DaemonSet", metadata: { name: "sunny-afternoon", namespace: "face2face" } },
+                { kind: "DaemonSet", metadata: { name: "kube-proxy", namespace: "kube-system" } },
+                { kind: "DaemonSet", metadata: { name: "sunny-afternoon", namespace: "face-to-face" } },
+                { kind: "Secret", metadata: { name: "default-token-12345", namespace: "default" }, type: "kubernetes.io/service-account-token" },
+                { kind: "Service", metadata: { name: "tired-of-waiting-for-you", namespace: "kinda-kinks" } },
+                { kind: "Service", metadata: { name: "kubernetes", namespace: "default" } },
+                { kind: "Service", metadata: { name: "kubernetes", namespace: "nondefault" } },
+                { kind: "ServiceAccount", metadata: { name: "tired-of-waiting-for-you", namespace: "kinda-kinks" } },
+                { kind: "ClusterRole", metadata: { name: "gce:cloud-provider" } },
+                { kind: "ClusterRole", metadata: { name: "the-kinks-are-the-village-green-preservation-society" } },
+                { kind: "ClusterRoleBinding", metadata: { name: "metrics-server:system:auth-delegator" } },
+            ];
+            const s = defaultKubernetesFetchOptions.selectors;
+            const o = selectKubernetesResources(r, s);
+            const e = [
+                { apiVersion: "v1", kind: "Secret", metadata: { name: "you-really-got-me", namespace: "kinks" } },
+                { kind: "Deployment", metadata: { name: "waterloo-sunset", namespace: "something-else" } },
+                { kind: "Deployment", metadata: { name: "waterloo-sunset-mono", namespace: "something-else" } },
+                { kind: "DaemonSet", metadata: { name: "sunny-afternoon", namespace: "face2face" } },
+                { kind: "DaemonSet", metadata: { name: "sunny-afternoon", namespace: "face-to-face" } },
+                { kind: "Service", metadata: { name: "tired-of-waiting-for-you", namespace: "kinda-kinks" } },
+                { kind: "Service", metadata: { name: "kubernetes", namespace: "nondefault" } },
+                { kind: "ServiceAccount", metadata: { name: "tired-of-waiting-for-you", namespace: "kinda-kinks" } },
+                { kind: "ClusterRole", metadata: { name: "the-kinks-are-the-village-green-preservation-society" } },
+            ];
+            assert.deepStrictEqual(o, e);
+        });
+
+        it("should properly filter resources", () => {
+            const labels = {
+                artist: "The Kinks",
+                leadVocals: "Ray Davies",
+                backingVocals: "Dave Davies",
+                rhythmGuitar: "Ray Davies",
+                leadGuitar: "Dave Davies",
+                bass: "Pete Quaife",
+                keyboards: "Ray Davies",
+                drums: "Mick Avory",
+                label: "Pye",
+                website: "https://thekinks.info/",
+            };
+            const r: K8sObject[] = [
+                { apiVersion: "v1", kind: "Secret", metadata: { name: "you-really-got-me", namespace: "kinks", labels } },
+                { kind: "Deployment", metadata: { name: "waterloo-sunset", namespace: "something-else", labels } },
+                { kind: "Deployment", metadata: { name: "waterloo-sunset-mono", namespace: "something-else", labels } },
+                { kind: "DaemonSet", metadata: { name: "sunny-afternoon", namespace: "face2face", labels } },
+                { kind: "DaemonSet", metadata: { name: "kube-proxy", namespace: "kube-system" } },
+                { kind: "DaemonSet", metadata: { name: "sunny-afternoon", namespace: "face-to-face", labels } },
+                { kind: "Service", metadata: { name: "waterloo-sunset", namespace: "something-else", labels } },
+                { kind: "Service", metadata: { name: "tired-of-waiting-for-you", namespace: "kinda-kinks", labels } },
+                { kind: "Service", metadata: { name: "kubernetes", namespace: "default" } },
+                { kind: "ServiceAccount", metadata: { name: "tired-of-waiting-for-you", namespace: "kinda-kinks", labels } },
+                { kind: "ServiceAccount", metadata: { name: "have-you-seen-her-face", namespace: "younger-than-yesterday" } },
+                { kind: "ClusterRole", metadata: { name: "the-kinks-are-the-village-green-preservation-society", labels } },
+            ];
+            const labelSelector: DeepPartial<k8s.V1LabelSelector> = {
+                matchExpressions: [
+                    { key: "rhythmGuitar", operator: "Exists" },
+                    { key: "label", operator: "In", values: ["Pye", "Reprise", "RCA", "Arista"] },
+                    { key: "bassoon", operator: "DoesNotExist" },
+                    { key: "leadVocals", operator: "NotIn", values: ["Mick Avory", "John 'Nobby' Dalton", "John Gosling"] },
+                ],
+                matchLabels: {
+                    artist: "The Kinks",
+                },
+            };
+            const s: KubernetesResourceSelector[] = [
+                { action: "exclude", name: /^waterloo/ },
+                { action: "include", kinds: [{ apiVersion: "v1", kind: "Service" }] },
+                { action: "exclude", name: "kubernetes", namespace: "default" },
+                { action: "include", name: "sunny-afternoon", namespace: /face/ },
+                { action: "exclude", kinds: [{ apiVersion: "apps/v1", kind: "DaemonSet" }] },
+                { action: "include", labelSelector },
+            ];
+            const o = selectKubernetesResources(r, s);
+            const e = [
+                { apiVersion: "v1", kind: "Secret", metadata: { name: "you-really-got-me", namespace: "kinks", labels } },
+                { kind: "DaemonSet", metadata: { name: "sunny-afternoon", namespace: "face2face", labels } },
+                { kind: "DaemonSet", metadata: { name: "sunny-afternoon", namespace: "face-to-face", labels } },
+                { kind: "Service", metadata: { name: "tired-of-waiting-for-you", namespace: "kinda-kinks", labels } },
+                { kind: "Service", metadata: { name: "kubernetes", namespace: "default" } },
+                { kind: "ServiceAccount", metadata: { name: "tired-of-waiting-for-you", namespace: "kinda-kinks", labels } },
+                { kind: "ClusterRole", metadata: { name: "the-kinks-are-the-village-green-preservation-society", labels } },
+            ];
+            assert.deepStrictEqual(o, e);
+        });
+
+    });
+
+    describe("selectorMatch", () => {
+
+        it("should match when no name/label selectors", () => {
+            const r: K8sObject = {
+                apiVersion: "v1",
+                kind: "Service",
+                metadata: {
+                    name: "my-back-pages",
+                    namespace: "byrds",
+                },
+            };
+            const s: KubernetesResourceSelector = {
+                action: "include",
+                kinds: [{ apiVersion: "v1", kind: "Service" }],
+            };
+            assert(selectorMatch(r, s));
+        });
+
+        it("should match on name selector", () => {
+            const r: K8sObject = {
+                apiVersion: "v1",
+                kind: "Service",
+                metadata: {
+                    name: "my-back-pages",
+                    namespace: "byrds",
+                },
+            };
+            const s: KubernetesResourceSelector = {
+                action: "include",
+                kinds: [{ apiVersion: "v1", kind: "Service" }],
+                name: "my-back-pages",
+            };
+            assert(selectorMatch(r, s));
+        });
+
+        it("should match on namespace selector", () => {
+            const r: K8sObject = {
+                apiVersion: "v1",
+                kind: "Service",
+                metadata: {
+                    name: "my-back-pages",
+                    namespace: "byrds",
+                },
+            };
+            const s: KubernetesResourceSelector = {
+                action: "include",
+                kinds: [{ apiVersion: "v1", kind: "Service" }],
+                namespace: /^b[iy]rds$/,
+            };
+            assert(selectorMatch(r, s));
+        });
+
+        it("should match on matchLabels selector", () => {
+            const r: K8sObject = {
+                apiVersion: "v1",
+                kind: "Service",
+                metadata: {
+                    labels: {
+                        album: "Younger Than Yesterday",
+                        year: "1967",
+                        recordLabel: "Columbia",
+                    },
+                    name: "my-back-pages",
+                    namespace: "byrds",
+                },
+            };
+            const s: KubernetesResourceSelector = {
+                action: "include",
+                kinds: [{ apiVersion: "v1", kind: "Service" }],
+                labelSelector: {
+                    matchLabels: {
+                        album: "Younger Than Yesterday",
+                        year: "1967",
+                    },
+                },
+            };
+            assert(selectorMatch(r, s));
+        });
+
+    });
+
+    describe("kindMatch", () => {
+
+        it("should match when no kinds", () => {
+            [[], undefined].forEach(k => {
+                const r = { kind: "Service" };
+                assert(kindMatch(r, k));
+            });
+        });
+
+        it("should match when kind is in kinds", () => {
+            const r = { kind: "Service" };
+            const k = [
+                { apiVersion: "apps/v1", kind: "Deployment" },
+                { apiVersion: "v1", kind: "Service" },
+                { apiVersion: "v1", kind: "ServiceAccount" },
+            ];
+            assert(kindMatch(r, k));
+        });
+
+        it("should not match when kind is not in kinds", () => {
+            const r = { kind: "Ingress" };
+            const k = [
+                { apiVersion: "apps/v1", kind: "Deployment" },
+                { apiVersion: "v1", kind: "Service" },
+                { apiVersion: "v1", kind: "ServiceAccount" },
+            ];
+            assert(!kindMatch(r, k));
+        });
+
+        it("should match regardless of apiVersion", () => {
+            const r = { apiVersion: "extensions/v1beta1", kind: "Deployment" };
+            const k = [
+                { apiVersion: "apps/v1", kind: "Deployment" },
+                { apiVersion: "v1", kind: "Service" },
+                { apiVersion: "v1", kind: "ServiceAccount" },
+            ];
+            assert(kindMatch(r, k));
+        });
+
+    });
+
+    describe("filterMatch", () => {
+
+        it("should match when no filter", () => {
+            const r = { kind: "Service" };
+            assert(filterMatch(r, undefined));
+        });
+
+        it("should match when filter matches", () => {
+            const r = { kind: "Service" };
+            assert(filterMatch(r, () => true));
+        });
+
+        it("should not match when filter does not match", () => {
+            const r = { kind: "Service" };
+            assert(!filterMatch(r, () => false));
+        });
+
+        it("should match a service account token", () => {
+            const r = {
+                apiVersion: "v1",
+                kind: "Secret",
+                metadata: {
+                    name: "default-token-7vxdj",
+                    namespace: "default",
+                },
+                type: "kubernetes.io/service-account-token",
+            };
+            const f = (s: any) => s.kind === "Secret" && s.type === "kubernetes.io/service-account-token";
+            assert(filterMatch(r, f));
+        });
+
+    });
+
+    describe("kubernetesFetch", function(): void {
+
+        // tslint:disable-next-line:no-invalid-this
+        this.timeout(5000);
+
+        let defaultRetries: number;
+
+        before(async function(): Promise<void> {
+            try {
+                // see if minikube is available and responding
+                await execPromise("kubectl", ["config", "use-context", "minikube"]);
+                await execPromise("kubectl", ["get", "--request-timeout=200ms", "pods"]);
+            } catch (e) {
+                // tslint:disable-next-line:no-invalid-this
+                this.skip();
+            }
+            defaultRetries = DefaultLogRetryOptions.retries;
+            DefaultLogRetryOptions.retries = 0;
+        });
+        after(() => {
+            if (defaultRetries) {
+                DefaultLogRetryOptions.retries = defaultRetries;
+            }
+        });
+
+        it("should fetch some resources", async () => {
+            const r = await kubernetesFetch();
+            assert(r, "kubernetesFetch did not return anything");
+        });
+
+    });
+
+});

--- a/test/kubernetes/name.test.ts
+++ b/test/kubernetes/name.test.ts
@@ -17,6 +17,7 @@
 import * as assert from "power-assert";
 import {
     defaultValidName,
+    nameMatch,
     validName,
 } from "../../lib/kubernetes/name";
 
@@ -63,6 +64,52 @@ describe("kubernetes/name", () => {
             assert(validation.test(v));
             const e = "a23456789112345678921234567893-234567894123456789512345678961";
             assert(v === e);
+        });
+
+    });
+
+    describe("nameMatch", () => {
+
+        it("should match a string", () => {
+            const v = "sicilian-crest";
+            const m = "sicilian-crest";
+            assert(nameMatch(v, m));
+        });
+
+        it("should match a regular expression", () => {
+            const v = "sicilian-crest";
+            const m = /cilian-cr/;
+            assert(nameMatch(v, m));
+        });
+
+        it("should not match a string", () => {
+            const v = "sicilian-crest";
+            const m = "sicilian-crust";
+            assert(!nameMatch(v, m));
+        });
+
+        it("should not match a regular expression", () => {
+            const v = "sicilian-crest";
+            const m = /cilain-cr/;
+            assert(!nameMatch(v, m));
+        });
+
+        it("should throw an error if matcher is neither a string nor regular expression", () => {
+            const v = "sicilian-crest";
+            const m: any = 2019;
+            assert.throws(() => nameMatch(v, m), /Provided matcher is neither a string or RegExp: /);
+        });
+
+        it("should match an empty string", () => {
+            const v = "";
+            const m = "";
+            assert(nameMatch(v, m));
+        });
+
+        it("should match when no matcher", () => {
+            const v = "sicilian-crest";
+            assert(nameMatch(v));
+            assert(nameMatch(v, undefined));
         });
 
     });

--- a/test/kubernetes/spec.test.ts
+++ b/test/kubernetes/spec.test.ts
@@ -1,0 +1,251 @@
+/*
+ * Copyright © 2019 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from "power-assert";
+import {
+    kubernetesSpecFileBasename,
+    kubernetesSpecStringify,
+} from "../../lib/kubernetes/spec";
+
+describe("kubernetes/spec", () => {
+
+    describe("kubernetesSpecFileBasename", () => {
+
+        it("should create a namespace file name", () => {
+            const o = {
+                apiVersion: "v1",
+                kind: "Namespace",
+                metadata: {
+                    name: "lyle",
+                },
+            };
+            const s = kubernetesSpecFileBasename(o);
+            assert(s === "10_lyle_namespace");
+        });
+
+        it("should create a simple namespaced file name", () => {
+            [
+                { a: "apps/v1", k: "Deployment", p: "70" },
+                { a: "extensions/v1beta1", k: "Ingress", p: "80" },
+                { a: "rbac.authorization.k8s.io/v1", k: "Role", p: "25" },
+                { a: "v1", k: "Secret", p: "60" },
+                { a: "v1", k: "Service", p: "50" },
+            ].forEach(r => {
+                const o = {
+                    apiVersion: r.a,
+                    kind: r.k,
+                    metadata: {
+                        name: "lyle",
+                        namespace: "lovett",
+                    },
+                };
+                const s = kubernetesSpecFileBasename(o);
+                const e = r.p + "_lovett_lyle_" + r.k.toLowerCase();
+                assert(s === e);
+            });
+        });
+
+        it("should create a kebab-case namespaced file name", () => {
+            [
+                { a: "v1", k: "ServiceAccount", l: "service-account", p: "20" },
+                { a: "rbac.authorization.k8s.io/v1", k: "RoleBinding", l: "role-binding", p: "30" },
+                { a: "apps/v1", k: "DaemonSet", l: "daemon-set", p: "70" },
+                { a: "networking.k8s.io/v1", k: "NetworkPolicy", l: "network-policy", p: "40" },
+                { a: "v1", k: "PersistentVolumeClaim", l: "persistent-volume-claim", p: "40" },
+                { a: "extensions/v1beta1", k: "PodSecurityPolicy", l: "pod-security-policy", p: "40" },
+                { a: "policy/v1beta1", k: "HorizontalPodAutoscaler", l: "horizontal-pod-autoscaler", p: "80" },
+                { a: "policy/v1beta1", k: "PodDisruptionBudget", l: "pod-disruption-budget", p: "80" },
+            ].forEach(r => {
+                const o = {
+                    apiVersion: r.a,
+                    kind: r.k,
+                    metadata: {
+                        name: "lyle",
+                        namespace: "lovett",
+                    },
+                };
+                const s = kubernetesSpecFileBasename(o);
+                const e = r.p + "_lovett_lyle_" + r.l;
+                assert(s === e);
+            });
+        });
+
+        it("should create a kebab-case cluster file name", () => {
+            [
+                { a: "v1", k: "PersistentVolume", l: "persistent-volume", p: "15" },
+                { a: "storage.k8s.io/v1", k: "StorageClass", l: "storage-class", p: "15" },
+                { a: "rbac.authorization.k8s.io/v1", k: "ClusterRole", l: "cluster-role", p: "25" },
+                { a: "rbac.authorization.k8s.io/v1", k: "ClusterRoleBinding", l: "cluster-role-binding", p: "30" },
+            ].forEach(r => {
+                const o = {
+                    apiVersion: r.a,
+                    kind: r.k,
+                    metadata: {
+                        name: "lyle",
+                    },
+                };
+                const s = kubernetesSpecFileBasename(o);
+                const e = r.p + "_lyle_" + r.l;
+                assert(s === e);
+            });
+        });
+
+    });
+
+    describe("kubernetesSpecStringify", () => {
+
+        it("should stringify a spec", async () => {
+            const r = {
+                apiVersion: "v1",
+                kind: "Service",
+                metadata: {
+                    name: "kubernetes",
+                    namespace: "default",
+                    labels: {
+                        component: "apiserver",
+                        provider: "kubernetes",
+                    },
+                },
+                spec: {
+                    type: "ClusterIP",
+                    ports: [
+                        {
+                            name: "https",
+                            protocol: "TCP",
+                            port: 443,
+                            targetPort: 8443,
+                        },
+                    ],
+                    sessionAffinity: "None",
+                    clusterIP: "10.96.0.1",
+                },
+            };
+            const s = await kubernetesSpecStringify(r);
+            const e = `{
+  "apiVersion": "v1",
+  "kind": "Service",
+  "metadata": {
+    "labels": {
+      "component": "apiserver",
+      "provider": "kubernetes"
+    },
+    "name": "kubernetes",
+    "namespace": "default"
+  },
+  "spec": {
+    "clusterIP": "10.96.0.1",
+    "ports": [
+      {
+        "name": "https",
+        "port": 443,
+        "protocol": "TCP",
+        "targetPort": 8443
+      }
+    ],
+    "sessionAffinity": "None",
+    "type": "ClusterIP"
+  }
+}
+`;
+            assert(s === e);
+        });
+
+        it("should stringify a spec to yaml", async () => {
+            const r = {
+                apiVersion: "v1",
+                kind: "Service",
+                metadata: {
+                    name: "kubernetes",
+                    namespace: "default",
+                    labels: {
+                        component: "apiserver",
+                        provider: "kubernetes",
+                    },
+                },
+                spec: {
+                    type: "ClusterIP",
+                    ports: [
+                        {
+                            name: "https",
+                            protocol: "TCP",
+                            port: 443,
+                            targetPort: 8443,
+                        },
+                    ],
+                    sessionAffinity: "None",
+                    clusterIP: "10.96.0.1",
+                },
+            };
+            const s = await kubernetesSpecStringify(r, { format: "yaml" });
+            const e = `apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    component: apiserver
+    provider: kubernetes
+  name: kubernetes
+  namespace: default
+spec:
+  clusterIP: 10.96.0.1
+  ports:
+    - name: https
+      port: 443
+      protocol: TCP
+      targetPort: 8443
+  sessionAffinity: None
+  type: ClusterIP
+`;
+            assert(s === e);
+        });
+
+        it("should encrypt secret values", async () => {
+            const r = {
+                apiVersion: "v1",
+                kind: "Secret",
+                type: "Opaque",
+                metadata: {
+                    name: "butterfly",
+                    namespace: "the-hollies",
+                },
+                data: {
+                    year: "MTk2Nw==",
+                    studio: "QWJiZXkgUm9hZCBTdHVkaW9z",
+                    producer: "Um9uIFJpY2hhcmRz",
+                },
+            };
+            const k = "Dear Eloise / King Midas in Reverse";
+            const s = await kubernetesSpecStringify(r, { secretKey: k });
+            const e = `{
+  "apiVersion": "v1",
+  "data": {
+    "producer": "fIXYFs7jyC5iLxbeC3iGuYdgMhA/hxHaX80SocbXKX4=",
+    "studio": "CC4ZtaHs9d3f5uZ9FoTAuLGel2mTG+Wmj6iOdssUoi4=",
+    "year": "gqOPJs0mmn7vj7PMjQl7Hg=="
+  },
+  "kind": "Secret",
+  "metadata": {
+    "name": "butterfly",
+    "namespace": "the-hollies"
+  },
+  "type": "Opaque"
+}
+`;
+            assert(s === e);
+        });
+
+    });
+
+});

--- a/test/sync/application.test.ts
+++ b/test/sync/application.test.ts
@@ -28,7 +28,6 @@ import { KubernetesApplication } from "../../lib/kubernetes/request";
 import {
     matchSpec,
     ProjectFileSpec,
-    specFileBasename,
     syncResources,
 } from "../../lib/sync/application";
 import { k8sSpecGlob } from "../../lib/sync/diff";
@@ -74,17 +73,6 @@ describe("sync/application", () => {
                             },
                         },
                     },
-                    {
-                        file: new InMemoryProjectFile("beta-dep.json", "{}"),
-                        spec: {
-                            apiVersion: "extensions/v1beta1",
-                            kind: "Deployment",
-                            metadata: {
-                                name: "lyle",
-                                namespace: "lovett",
-                            },
-                        },
-                    },
                 ],
             ];
             sss.forEach(ss => {
@@ -103,7 +91,7 @@ describe("sync/application", () => {
 
         it("should find the file spec", () => {
             const s = {
-                apiVersion: "v1",
+                apiVersion: "apps/v1",
                 kind: "Deployment",
                 metadata: {
                     name: "lyle",
@@ -114,7 +102,33 @@ describe("sync/application", () => {
                 {
                     file: new InMemoryProjectFile("dep.json", "{}"),
                     spec: {
-                        apiVersion: "v1",
+                        apiVersion: "apps/v1",
+                        kind: "Deployment",
+                        metadata: {
+                            name: "lyle",
+                            namespace: "lovett",
+                        },
+                    },
+                },
+            ];
+            const m = matchSpec(s, ss);
+            assert.deepStrictEqual(m, ss[0]);
+        });
+
+        it("should find the file spec with different apiVersion", () => {
+            const s = {
+                apiVersion: "apps/v1",
+                kind: "Deployment",
+                metadata: {
+                    name: "lyle",
+                    namespace: "lovett",
+                },
+            };
+            const ss: ProjectFileSpec[] = [
+                {
+                    file: new InMemoryProjectFile("dep.json", "{}"),
+                    spec: {
+                        apiVersion: "extensions/v1beta1",
                         kind: "Deployment",
                         metadata: {
                             name: "lyle",
@@ -171,94 +185,19 @@ describe("sync/application", () => {
                     },
                 },
                 {
-                    file: new InMemoryProjectFile("beta-dep.json", "{}"),
+                    file: new InMemoryProjectFile("dep.json", "{}"),
                     spec: {
-                        apiVersion: "extensions/v1beta1",
+                        apiVersion: "apps/v1",
                         kind: "Deployment",
                         metadata: {
                             name: "lyle",
-                            namespace: "lovett",
+                            namespace: "alzado",
                         },
                     },
                 },
             ];
             const m = matchSpec(s, ss);
             assert.deepStrictEqual(m, ss[2]);
-        });
-
-    });
-
-    describe("specFileBasename", () => {
-
-        it("should create a namespace file name", () => {
-            const o = {
-                apiVersion: "v1",
-                kind: "Namespace",
-                metadata: {
-                    name: "lyle",
-                },
-            };
-            const s = specFileBasename(o);
-            assert(s === "10_lyle_namespace");
-        });
-
-        it("should create a simple namespaced file name", () => {
-            [
-                { k: "Deployment", p: "70" },
-                { k: "Ingress", p: "80" },
-                { k: "Role", p: "25" },
-                { k: "Secret", p: "60" },
-                { k: "Service", p: "50" },
-            ].forEach(r => {
-                const o = {
-                    apiVersion: "v1",
-                    kind: r.k,
-                    metadata: {
-                        name: "lyle",
-                        namespace: "lovett",
-                    },
-                };
-                const s = specFileBasename(o);
-                const e = r.p + "_lovett_lyle_" + r.k.toLowerCase();
-                assert(s === e);
-            });
-        });
-
-        it("should create a kebab-case namespaced file name", () => {
-            [
-                { k: "RoleBinding", l: "role-binding", p: "30" },
-                { k: "ServiceAccount", l: "service-account", p: "20" },
-            ].forEach(r => {
-                const o = {
-                    apiVersion: "v1",
-                    kind: r.k,
-                    metadata: {
-                        name: "lyle",
-                        namespace: "lovett",
-                    },
-                };
-                const s = specFileBasename(o);
-                const e = r.p + "_lovett_lyle_" + r.l;
-                assert(s === e);
-            });
-        });
-
-        it("should create a kebab-case cluster file name", () => {
-            [
-                { k: "ClusterRole", l: "cluster-role", p: "25" },
-                { k: "ClusterRoleBinding", l: "cluster-role-binding", p: "30" },
-            ].forEach(r => {
-                const o = {
-                    apiVersion: "rbac.authorization.k8s.io/v1",
-                    kind: r.k,
-                    metadata: {
-                        name: "lyle",
-                    },
-                };
-                const s = specFileBasename(o);
-                const e = r.p + "_lyle_" + r.l;
-                assert(s === e);
-            });
         });
 
     });


### PR DESCRIPTION
Add ability to fetch Kubernetes resource specs from a cluster.  These
specs could be used to replicated resources across multiple clusters,
migrate resources, or just bootstrap GitOps.

Update @kubernetes/client-node and fix compilation.

Closes #59