### PR TITLE
Add repo sync command

### DIFF
--- a/lib/config.ts
+++ b/lib/config.ts
@@ -26,9 +26,9 @@ import * as _ from "lodash";
  */
 export interface SdmPackK8sOptions {
     /**
-     * Whether to add the undelete command.  Typically you would only
-     * want to enable this in one SDM per workspace.  If no value is
-     * provided, the comand is not added.
+     * Whether to add the bot/web-app commands provided by this SDM
+     * extension pack.  If no value is provided, the commands are not
+     * added.
      */
     addCommands?: boolean;
 

--- a/lib/k8s.ts
+++ b/lib/k8s.ts
@@ -29,6 +29,7 @@ import { providerStartupListener } from "./provider/kubernetesCluster";
 import { minikubeStartupListener } from "./support/minikube";
 import { syncGoals } from "./sync/goals";
 import { syncRepoStartupListener } from "./sync/startup";
+import { kubernetesSync } from "./sync/sync";
 
 /**
  * Register Kubernetes deployment support for provided goals.  Any
@@ -38,7 +39,8 @@ import { syncRepoStartupListener } from "./sync/startup";
  * object, with those passed in taking precedence.
  *
  * If the merged options result in a truthy `addCommands`, then the
- * [[kubernetesUndeploy]] command is added to the SDM.
+ * [[kubernetesUndeploy]] and [[kubernetesSync]] commands are added to
+ * the SDM.
  *
  * The [[kubernetesDeployHandler]] event handler for this SDM is added
  * to the SDM.
@@ -62,6 +64,7 @@ export function k8sSupport(options: SdmPackK8sOptions = {}): ExtensionPack {
 
             if (sdm.configuration.sdm.k8s.options.addCommands) {
                 sdm.addCommand(kubernetesUndeploy(sdm));
+                sdm.addCommand(kubernetesSync(sdm));
             }
 
             sdm.addEvent(kubernetesDeployHandler(sdm.configuration.name));

--- a/lib/sync/startup.ts
+++ b/lib/sync/startup.ts
@@ -14,21 +14,27 @@
  * limitations under the License.
  */
 
-import { StartupListener } from "@atomist/sdm";
+import { logger } from "@atomist/automation-client";
+import {
+    createJob,
+    fakeContext,
+    SoftwareDeliveryMachine,
+    StartupListener,
+} from "@atomist/sdm";
 import { isInLocalMode } from "@atomist/sdm-core";
 import * as cluster from "cluster";
 import * as _ from "lodash";
 import { queryForScmProvider } from "./repo";
-import { repoSync } from "./sync";
+import { KubernetesSync } from "./sync";
 
 /**
  * If the SDM is registered with one or more workspaces and not
  * running in local mode, query cortex for the sync repo and replace
  * the sdm.k8s.options.sync.repo property with a RemoteRepoRef for
- * that repo.  If this is the cluster master, run [[repoSync]].  If
- * this is the cluster master and the SDM configuration has a
- * [[KubernetesSyncOptions]] with a positive value of
- * `intervalMinutes`, it will set up an interval timer to apply the
+ * that repo.  If this is the cluster master, it will create a job to
+ * perform a sync.  If this is the cluster master and the SDM
+ * configuration has a [[KubernetesSyncOptions]] with a positive value
+ * of `intervalMinutes`, it will set up an interval timer to apply the
  * specs from the sync repo periodically.
  */
 export const syncRepoStartupListener: StartupListener = async ctx => {
@@ -42,10 +48,30 @@ export const syncRepoStartupListener: StartupListener = async ctx => {
     if (!cluster.isMaster) {
         return;
     }
-    await repoSync(sdm);
+    await sdmRepoSync(sdm);
     const interval: number = _.get(sdm, "configuration.sdm.k8s.options.sync.intervalMinutes");
     if (interval && interval > 0) {
-        setInterval(() => repoSync(sdm), interval * 60 * 1000);
+        logger.info(`Creating sync repo trigger every ${interval} minutes`);
+        /* See https://github.com/atomist/sdm/issues/762
+        sdm.addTriggeredListener({
+            trigger: { interval: interval * 60 * 1000 },
+            listener: li => sdmRepoSync(li.sdm),
+        });
+        */
+        setInterval(() => sdmRepoSync(sdm), interval * 60 * 1000);
     }
     return;
 };
+
+/**
+ * Create the trappings required for executing a command and then
+ * create a job to execute the [[kubernetesSync]] command.
+ */
+async function sdmRepoSync(sdm: SoftwareDeliveryMachine): Promise<void> {
+    const workspaceId = sdm.configuration.workspaceIds[0];
+    const context = fakeContext(workspaceId);
+    context.graphClient = sdm.configuration.graphql.client.factory.create(workspaceId, sdm.configuration);
+    logger.info("Creating sync repo job");
+    await createJob({ command: KubernetesSync, parameters: [{}] }, context);
+    return;
+}

--- a/lib/sync/sync.ts
+++ b/lib/sync/sync.ts
@@ -16,12 +16,15 @@
 
 import {
     GitProject,
+    HandlerResult,
     logger,
     ProjectFile,
 } from "@atomist/automation-client";
 import {
-    fakeContext,
+    CommandHandlerRegistration,
+    CommandListenerInvocation,
     ProjectLoadingParameters,
+    slackSuccessMessage,
     SoftwareDeliveryMachine,
 } from "@atomist/sdm";
 import * as _ from "lodash";
@@ -30,41 +33,78 @@ import { parseKubernetesSpecFile } from "../deploy/spec";
 import { applySpec } from "../kubernetes/apply";
 import { decryptSecret } from "../kubernetes/secret";
 import { errMsg } from "../support/error";
+import { cleanName } from "../support/name";
 import { defaultCloneOptions } from "./clone";
 import { k8sSpecGlob } from "./diff";
+import { isRemoteRepo } from "./repo";
+
+export const KubernetesSync = "KubernetesSync";
+
+/**
+ * Command to synchronize the resources in a Kubernetes cluster with
+ * the resource specs in the configured sync repo.  The sync repo will
+ * be cloned and the resources applied against the Kubernetes API in
+ * lexical order sorted by file name.  If no sync repo is configured
+ * in the SDM, the command errors.  This command is typically executed
+ * on an interval timer by setting the `intervalMinutes`
+ * [[KubernetesSyncOptions]].
+ */
+export function kubernetesSync(sdm: SoftwareDeliveryMachine): CommandHandlerRegistration {
+    return {
+        intent: `kube sync ${cleanName(sdm.configuration.name)}`,
+        name: KubernetesSync,
+        listener: repoSync,
+    };
+}
 
 /**
  * Clone the sync repo and apply the specs to the Kubernetes cluster.
  */
-export async function repoSync(sdm: SoftwareDeliveryMachine): Promise<void> {
-    const disposers: Array<() => Promise<void>> = [];
-    const workspaceId: string = _.get(sdm, "configuration.workspaceIds[0]");
-    const context = fakeContext(workspaceId);
-    context.lifecycle = {
-        dispose: async () => { await Promise.all(disposers.map(d => d())); },
-        registerDisposable: (d: () => Promise<void>) => { disposers.push(d); },
-    };
+export async function repoSync(cli: CommandListenerInvocation): Promise<HandlerResult> {
+    const opts: KubernetesSyncOptions = _.get(cli.configuration, "sdm.k8s.options.sync");
+    if (!opts) {
+        const message = `SDM has no sync options defined`;
+        logger.error(message);
+        await cli.context.messageClient.respond(message);
+        return { code: 2, message };
+    }
+    if (!isRemoteRepo(opts.repo)) {
+        const message = `SDM sync option repo is not a valid remote repo`;
+        logger.error(message);
+        await cli.context.messageClient.respond(message);
+        return { code: 2, message };
+    }
+
     const projectLoadingParameters: ProjectLoadingParameters = {
-        credentials: sdm.configuration.sdm.k8s.options.sync.credentials,
+        credentials: opts.credentials,
         cloneOptions: defaultCloneOptions,
-        context,
-        id: sdm.configuration.sdm.k8s.options.sync.repo,
+        context: cli.context,
+        id: opts.repo,
         readOnly: true,
     };
-    const opts: KubernetesSyncOptions = _.get(sdm, "configuration.sdm.k8s.options.sync");
+    const slug = `${opts.repo.owner}/${opts.repo.repo}`;
     try {
-        await sdm.configuration.sdm.projectLoader.doWithProject(projectLoadingParameters, syncApply(opts));
+        logger.info(`Starting sync of repo ${slug}`);
+        await cli.configuration.sdm.projectLoader.doWithProject(projectLoadingParameters, syncApply(opts));
     } catch (e) {
-        e.message = `Failed to perform sync using repo ${opts.repo.owner}/${opts.repo.repo}: ${e.message}`;
-        logger.error(e.message);
-    } finally {
-        try {
-            await context.lifecycle.dispose();
-        } catch (e) {
-            logger.warn(`Failed to clean up sync repo: ${e.message}`);
-        }
+        const message = `Failed to sync repo ${slug}: ${e.message}`;
+        logger.error(message);
+        await cli.context.messageClient.respond(message);
+        return { code: 1, message };
     }
-    return;
+    const result: HandlerResult = {
+        code: 0,
+        message: `Successfully completed sync of repo ${slug}`,
+    };
+    logger.info(result.message);
+    try {
+        await cli.context.messageClient.respond(slackSuccessMessage("Kubernetes Sync", result.message));
+    } catch (e) {
+        result.code++;
+        result.message = `${result.message}; Failed to send response message: ${e.message}`;
+        logger.error(result.message);
+    }
+    return result;
 }
 
 /**

--- a/test/sync/sync.test.ts
+++ b/test/sync/sync.test.ts
@@ -15,11 +15,19 @@
  */
 
 import {
+    GitHubRepoRef,
     GitProject,
     InMemoryProject,
 } from "@atomist/automation-client";
+import * as acglobals from "@atomist/automation-client/lib/globals";
+import { fakeContext } from "@atomist/sdm";
 import * as assert from "power-assert";
-import { sortSpecs } from "../../lib/sync/sync";
+import { K8sObject } from "../../lib/kubernetes/api";
+import * as apply from "../../lib/kubernetes/apply";
+import {
+    repoSync,
+    sortSpecs,
+} from "../../lib/sync/sync";
 
 describe("sync/sync", () => {
 
@@ -71,6 +79,254 @@ describe("sync/sync", () => {
             assert(s[3].name === "60-d-service.json");
             assert(s[4].name === "80-a-deployment.yaml");
             assert(s[5].name === "80-b-deployment.json");
+        });
+
+    });
+
+    describe("repoSync", () => {
+
+        let originalApplySpec: any;
+        let originalAutomationClient: any;
+        let specs: K8sObject[];
+        before(() => {
+            originalApplySpec = Object.getOwnPropertyDescriptor(apply, "applySpec");
+            Object.defineProperty(apply, "applySpec", {
+                value: async (s: K8sObject) => {
+                    specs.push(s);
+                    return {
+                        body: s,
+                        response: { code: 200 },
+                    };
+                },
+            });
+            originalAutomationClient = Object.getOwnPropertyDescriptor(acglobals, "automationClientInstance");
+        });
+        after(() => {
+            Object.defineProperty(apply, "applySpec", originalApplySpec);
+            Object.defineProperty(acglobals, "automationClientInstance", originalAutomationClient);
+        });
+        beforeEach(() => {
+            specs = [];
+        });
+
+        const r: GitProject = InMemoryProject.of(
+            { path: "README.md", content: "# Joe Henry\n## Scar\n" },
+            { path: "70_jlh_stop_deployment.json", content: `{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"name":"stop"}}` },
+            { path: "60_jlh_stop_service.json", content: `{"apiVersion":"v1","kind":"Service","metadata":{"name":"stop","namespace":"jlh"}}` },
+            { path: "index.ts", content: "#! /usr/bin/env node\n" },
+            { path: "assets/kubectl/60-d-service.json", content: `{"metadata":{"annotations":{}}}` },
+            { path: "70_scar_scar_dep.yaml", content: "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: scar\n  namespace: scar\n" },
+            { path: "lib/stuff.ts", content: "// comment\n" },
+            { path: "00_guest_ornette_ds.json", content: `{"apiVersion":"apps/v1","kind":"DaemonSet","metadata":{"name":"ornette"}}` },
+            { path: "80_jlh_stop_ingress.yml", content: "apiVersion: networking.k8s.io/v1\nkind: Ingress\n" },
+            { path: "test/stuff.test.ts", content: "/* comment */" },
+            { path: "60_jlh_stop_secret.yml", content: "apiVersion: v1\nkind: Secret\ndata:\n  amor: +WgqDCG3DW42vXwmS/ZYAg==\n" },
+        ) as any;
+        const context = fakeContext("AT34RFU1N4T10N");
+
+        it("should sync the repo successfully", async () => {
+            let loaded = false;
+            const cli: any = {
+                configuration: {
+                    name: "@joe-henry/scar",
+                    sdm: {
+                        k8s: {
+                            options: {
+                                sync: {
+                                    credentials: { token: "RichardPryorAddressesATearfulNation" },
+                                    repo: GitHubRepoRef.from({
+                                        branch: "scar",
+                                        owner: "reprise",
+                                        repo: "JoeHenry",
+                                    }),
+                                    secretKey: "Edgar Bergen",
+                                },
+                            },
+                        },
+                        projectLoader: {
+                            doWithProject: async (p: any, a: any) => {
+                                loaded = true;
+                                assert(p.credentials.token === "RichardPryorAddressesATearfulNation");
+                                assert(p.id.branch === "scar");
+                                assert(p.id.owner === "reprise");
+                                assert(p.id.repo === "JoeHenry");
+                                assert(p.readOnly === true);
+                                return a(r);
+                            },
+                        },
+                    },
+                },
+                context,
+            };
+            Object.defineProperty(acglobals, "automationClientInstance", {
+                value: () => ({ configuration: cli.configuration }),
+            });
+            const v = await repoSync(cli);
+            assert(v.code === 0);
+            assert(v.message === "Successfully completed sync of repo reprise/JoeHenry");
+            assert(loaded, "Project was never loaded");
+            const eSpecs = [
+                { apiVersion: "apps/v1", kind: "DaemonSet", metadata: { name: "ornette" } },
+                { apiVersion: "v1", kind: "Secret", data: { amor: "U3RvcA==" } },
+                { apiVersion: "v1", kind: "Service", metadata: { name: "stop", namespace: "jlh" } },
+                { apiVersion: "apps/v1", kind: "Deployment", metadata: { name: "stop" } },
+                { apiVersion: "apps/v1", kind: "Deployment", metadata: { name: "scar", namespace: "scar" } },
+                { apiVersion: "networking.k8s.io/v1", kind: "Ingress" },
+            ];
+            assert.deepStrictEqual(specs, eSpecs);
+        });
+
+        it("should detect if there are no sync options", async () => {
+            const cli: any = {
+                configuration: {
+                    sdm: {
+                        k8s: {},
+                        projectLoader: {
+                            doWithProject: async () => { },
+                        },
+                    },
+                },
+                context,
+            };
+            const v = await repoSync(cli);
+            assert(v.code === 2);
+            assert(v.message === "SDM has no sync options defined");
+        });
+
+        it("should detect if sync repo is not a RemoteRepoRef", async () => {
+            const cli: any = {
+                configuration: {
+                    sdm: {
+                        k8s: {
+                            options: {
+                                sync: {
+                                    credentials: { token: "RichardPryorAddressesATearfulNation" },
+                                    repo: {
+                                        branch: "scar",
+                                        owner: "reprise",
+                                        repo: "JoeHenry",
+                                    },
+                                    secretKey: "Edgar Bergen",
+                                },
+                            },
+                        },
+                        projectLoader: {
+                            doWithProject: async () => { },
+                        },
+                    },
+                },
+                context,
+            };
+            const v = await repoSync(cli);
+            assert(v.code === 2);
+            assert(v.message === "SDM sync option repo is not a valid remote repo");
+        });
+
+        it("should detect a failure", async () => {
+            const cli: any = {
+                configuration: {
+                    sdm: {
+                        k8s: {
+                            options: {
+                                sync: {
+                                    credentials: { token: "RichardPryorAddressesATearfulNation" },
+                                    repo: GitHubRepoRef.from({
+                                        branch: "scar",
+                                        owner: "reprise",
+                                        repo: "JoeHenry",
+                                    }),
+                                    secretKey: "Edgar Bergen",
+                                },
+                            },
+                        },
+                        projectLoader: {
+                            doWithProject: async (p: any, a: any) => {
+                                throw new Error("doWithProject failure");
+                            },
+                        },
+                    },
+                },
+                context,
+            };
+            const v = await repoSync(cli);
+            assert(v.code === 1);
+            assert(v.message === "Failed to sync repo reprise/JoeHenry: doWithProject failure");
+        });
+
+    });
+
+    describe("repoSync apply failure", () => {
+
+        let originalApplySpec: any;
+        let specs: K8sObject[];
+        before(() => {
+            originalApplySpec = Object.getOwnPropertyDescriptor(apply, "applySpec");
+            Object.defineProperty(apply, "applySpec", {
+                value: async (s: K8sObject) => {
+                    if (s.apiVersion === "apps/v1" && s.kind === "Deployment" && s.metadata.name === "stop") {
+                        throw new Error("applySpec failure");
+                    }
+                    specs.push(s);
+                },
+            });
+        });
+        after(() => {
+            Object.defineProperty(apply, "applySpec", originalApplySpec);
+        });
+        beforeEach(() => {
+            specs = [];
+        });
+
+        it("should handle applySpec failure", async () => {
+            const r: GitProject = InMemoryProject.of(
+                { path: "README.md", content: "# Joe Henry\n## Scar\n" },
+                { path: "d.json", content: `{"apiVersion":"apps/v1","kind":"Deployment","metadata":{"name":"stop"}}` },
+                { path: "60_jlh_stop_service.json", content: `{"apiVersion":"v1","kind":"Service","metadata":{"name":"stop","namespace":"jlh"}}` },
+                { path: "index.ts", content: "#! /usr/bin/env node\n" },
+                { path: "assets/kubectl/60-d-service.json", content: `{"metadata":{"annotations":{}}}` },
+                { path: "70_scar_scar_dep.yaml", content: "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: scar\n  namespace: scar\n" },
+                { path: "lib/stuff.ts", content: "// comment\n" },
+                { path: "00_guest_ornette_ds.json", content: `{"apiVersion":"apps/v1","kind":"DaemonSet","metadata":{"name":"ornette"}}` },
+                { path: "80_jlh_stop_ingress.yml", content: "apiVersion: networking.k8s.io/v1\nkind: Ingress\n" },
+                { path: "test/stuff.test.ts", content: "/* comment */" },
+                { path: "60_jlh_stop_secret.yml", content: "apiVersion: v1\nkind: Secret\ndata:\n  amor: +WgqDCG3DW42vXwmS/ZYAg==\n" },
+            ) as any;
+            const context = fakeContext("AT34RFU1N4T10N");
+            const cli: any = {
+                configuration: {
+                    sdm: {
+                        k8s: {
+                            options: {
+                                sync: {
+                                    credentials: { token: "RichardPryorAddressesATearfulNation" },
+                                    repo: GitHubRepoRef.from({
+                                        branch: "scar",
+                                        owner: "reprise",
+                                        repo: "JoeHenry",
+                                    }),
+                                    secretKey: "Edgar Bergen",
+                                },
+                            },
+                        },
+                        projectLoader: {
+                            doWithProject: async (p: any, a: any) => a(r),
+                        },
+                    },
+                },
+                context,
+            };
+            const v = await repoSync(cli);
+            assert(v.code === 1);
+            assert(v.message ===
+                "Failed to sync repo reprise/JoeHenry: There were errors during repo sync: Failed to apply 'd.json': applySpec failure");
+            const eSpecs = [
+                { apiVersion: "apps/v1", kind: "DaemonSet", metadata: { name: "ornette" } },
+                { apiVersion: "v1", kind: "Secret", data: { amor: "U3RvcA==" } },
+                { apiVersion: "v1", kind: "Service", metadata: { name: "stop", namespace: "jlh" } },
+                { apiVersion: "apps/v1", kind: "Deployment", metadata: { name: "scar", namespace: "scar" } },
+                { apiVersion: "networking.k8s.io/v1", kind: "Ingress" },
+            ];
+            assert.deepStrictEqual(specs, eSpecs);
         });
 
     });


### PR DESCRIPTION
Wrap sync repo functionality in a command.  Use command to run sync of
entire repo as a job so it gets scheduled in a worker.

Fix naming of kube undeploy.

@cdupuis do you think this would work?